### PR TITLE
ansible vault Azure Key Vault support

### DIFF
--- a/mars_macos.sh
+++ b/mars_macos.sh
@@ -73,9 +73,9 @@ if [ -z "$(docker ps | grep pinata-sshd)" ]; then
     pinata-ssh-forward
 fi
 
-DOCKER_TERM_VARS=-i
-if [ -t 1 -a ! -p /dev/stdin ]; then
-    DOCKER_TERM_VARS=-it
+DOCKER_TERM_VARS=''
+if [ -t 1 -a -p /dev/stdin ]; then
+    DOCKER_TERM_VARS=-i
 fi
 
 docker volume create "$ANSIBLE_INVENTORY_CACHE_VOL" >/dev/null

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ boto==2.49.0
 PyYAML==6.0
 python-dotenv==0.19.2
 requests==2.31.0
-azure-cli==2.40.0
 kubernetes==24.2.0
 jsonpatch==1.32
+azure-cli==2.50.0
+azure-keyvault-secrets==4.7.0
+azure-identity==1.13.0

--- a/scripts/keyvault.py
+++ b/scripts/keyvault.py
@@ -1,0 +1,8 @@
+from azure.keyvault.secrets import SecretClient
+from azure.identity import DefaultAzureCredential
+
+def get_secret(az_vault, az_vault_key):
+    vault_uri = f'https://{az_vault}.vault.azure.net'
+    credential = DefaultAzureCredential()
+    client = SecretClient(vault_url=vault_uri, credential=credential)
+    return client.get_secret(az_vault_key).value

--- a/scripts/vault-az-keyvault.py
+++ b/scripts/vault-az-keyvault.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import os
+
+import keyvault
+
+# load Azure Key Vault name and key from environment variables
+vault = os.environ["AZ_KEYVAULT_NAME"]
+key = os.environ["AZ_KEYVAULT_KEY"]
+
+secret = keyvault.get_secret(vault, key)
+print(secret, end="")


### PR DESCRIPTION
This adds support for Azure Key Vault stored vault keys to the ansible wrapper and refactors the wrapper to simplify it and improve extensibility.

This removes the `ansible-vault-{view,edit}` commands and reworks the `ansible-vault-{encrypt,decrypt}` commands to use the ansible python libraries directly and keep all keys in memory.  There is also a new `ansible-vault-decrypt-key` command that directly decrypts a specific key from a yaml file to avoid the need for copy paste.

The `ansible-playbook` command could not be easily implemented as an API call, so it supports Key Vault via the ansible vault client script API using a script that takes environment variables.  See:
https://docs.ansible.com/ansible/6/user_guide/vault.html#storing-passwords-in-third-party-tools-with-vault-password-client-scripts