### PR TITLE
fix anchor peers script

### DIFF
--- a/ansible-roles/k8s_fabric_scripts/files/scripts/anchor-peers.sh
+++ b/ansible-roles/k8s_fabric_scripts/files/scripts/anchor-peers.sh
@@ -13,12 +13,11 @@ ANCHORTX=./channel-artifacts/${MSP}anchors.tx
 
 pod="$(select_first_cli_pod "$ORG" 0)"
 
-WORKDIR=/opt/blocks/update-anchor-peers-$(date +%s)
-echo "WORKDIR=$WORKDIR"
-
-LOCAL_CONFIG_JSON=/tmp/$CHANNELBLOCK.json
-
-pod_exec "$pod" mkdir -p $WORKDIR
+LOCAL_CONFIG_JSON="$(mktemp "/tmp/${CHANNELBLOCK}.json.XXXXXX")"
+function cleanup {
+    rm -f "$LOCAL_CONFIG_JSON"
+}
+trap cleanup EXIT INT QUIT TERM
 
 "${BASH_SOURCE%/*}/get-channel-config.sh" "$ORG" "$LOCAL_CONFIG_JSON"
 if [[ $? -ne 0 ]]; then

--- a/ansible-roles/k8s_fabric_scripts/files/scripts/get-channel-config.sh
+++ b/ansible-roles/k8s_fabric_scripts/files/scripts/get-channel-config.sh
@@ -11,8 +11,6 @@ CONFIG_PATH=$2
 BLOCK_NAME=channel_config.pb
 BLOCK_JSON=channel_config.json
 
-[ ! -e "$CONFIG_PATH" ]
-
 NAMESPACE="fabric-$ORG_NAME"
 
 source "${BASH_SOURCE%/*}/channel-utils.sh"
@@ -27,8 +25,15 @@ REMOTE_BLOCK_JSON="$WORKDIR/channel_config.json"
 
 pod_exec "$pod" mkdir -p $WORKDIR
 
-pod_exec "$pod" peer channel fetch config "$REMOTE_BLOCK_PATH" -o "$ORDERER" -c "$CHANNEL" --tls --cafile "$ORDERER_CA"
+pod_exec "$pod" peer channel fetch config \
+         -o "$ORDERER" -c "$CHANNEL" \
+         --tls --cafile "$ORDERER_CA" \
+         "$REMOTE_BLOCK_PATH"
 
-pod_exec "$pod" configtxlator proto_decode --input "$REMOTE_BLOCK_PATH" --output "$REMOTE_BLOCK_JSON" --type common.Block
+pod_exec "$pod" configtxlator proto_decode \
+         --input "$REMOTE_BLOCK_PATH" \
+         --output "$REMOTE_BLOCK_JSON" \
+         --type common.Block
 
-pod_exec "$pod" jq .data.data[0].payload.data.config "$REMOTE_BLOCK_JSON" > ${CONFIG_PATH}
+pod_exec "$pod" jq .data.data[0].payload.data.config \
+         "$REMOTE_BLOCK_JSON" > "$CONFIG_PATH"


### PR DESCRIPTION
This addresses a regression where a temporary file was using a fixed name and not allowed to be overwritten.  The file is now randomly named, deleted on exit, and the channel config script now allows overwriting existing output files.