### PR TITLE
Sam at luther/add fabriccli affinity

### DIFF
--- a/ansible-roles/k8s_fabric_cli/files/fabric-cli/templates/deployment.yaml
+++ b/ansible-roles/k8s_fabric_cli/files/fabric-cli/templates/deployment.yaml
@@ -241,10 +241,20 @@ spec:
         {{- end }}
       nodeSelector:
         topology.kubernetes.io/zone: {{ .Values.availabilityZone }}
-      {{- with .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "fabric/organization"
+                    operator: In
+                    values:
+                      - {{ .Values.dlt.organization }}
+                  - key: "fabric/organization-index"
+                    operator: In
+                    values:
+                      - {{ .Values.dlt.peerIndex | print | toJson }}
+              topologyKey: "kubernetes.io/hostname"
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/ansible-roles/k8s_fabric_orderer/files/fabric-orderer/templates/_helpers.tpl
+++ b/ansible-roles/k8s_fabric_orderer/files/fabric-orderer/templates/_helpers.tpl
@@ -53,6 +53,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/component: {{ .Values.dlt.component }}
 app.kubernetes.io/part-of: {{ .Values.global.partOf }}
+fabric/organization: {{ .Values.dlt.organization }}
 fabric/organization-index: {{ .Values.dlt.organizationIndex | print | toJson }}
 {{- end -}}
 


### PR DESCRIPTION
This is in preparation for the batch jobs which will reuse the cli spec and require scheduling on the same node as the corresponding peer/orderer. In general though this is a good optimization, as it explicitly places the pod on the same node as the corresponding peer/order that the cli is configured to manage, as opposed to just the AZ nodeSelector. 