### PR TITLE
configurable python path

### DIFF
--- a/ansible-roles/bastion_init/tasks/main.yaml
+++ b/ansible-roles/bastion_init/tasks/main.yaml
@@ -120,16 +120,9 @@
 
 - import_role:
     name: kubectl
-
-- name: Configure kubectl for EKS
-  command:
-    argv:
-      - aws
-      - "--region={{kubectl_eks_region|quote}}"
-      - eks
-      - update-kubeconfig
-      - "--name={{kubectl_eks_cluster_name|quote}}"
-  environment: "{{ kubectl_env }}"
+  vars:
+    kubectl_configure: yes
+    kubectl_python_interpreter: "{{ bastion_init_virtualenv }}/bin/python"
 
 - name: Set kubeconfig.yaml permissions
   file:

--- a/ansible-roles/kubectl/defaults/main.yml
+++ b/ansible-roles/kubectl/defaults/main.yml
@@ -25,3 +25,5 @@ kubectl_aws_role_arn: ""
 
 kubectl_configure: no
 kubectl_configured: no
+
+kubectl_python_interpreter: ""

--- a/ansible-roles/kubectl/tasks/env.yml
+++ b/ansible-roles/kubectl/tasks/env.yml
@@ -31,7 +31,8 @@
 
 - name: override ansible interpreter
   set_fact:
-    ansible_python_interpreter: /opt/ansible_venv/bin/python
+    ansible_python_interpreter: "{{ kubectl_python_interpreter }}"
+  when: kubectl_python_interpreter != ""
 
 - name: Configure kubectl for EKS
   command:


### PR DESCRIPTION
This exposes a variable for configuring the kubectl role's python interpreter override and disables it by default.  This also removes the redundant kubeconfig setup block.