### PR TITLE
kubectl venv fix

### DIFF
--- a/ansible-roles/kubectl/defaults/main.yml
+++ b/ansible-roles/kubectl/defaults/main.yml
@@ -26,4 +26,4 @@ kubectl_aws_role_arn: ""
 kubectl_configure: no
 kubectl_configured: no
 
-kubectl_python_interpreter: ""
+kubectl_python_interpreter: /opt/mars_venv/bin/python

--- a/ansible-roles/kubectl/tasks/env.yml
+++ b/ansible-roles/kubectl/tasks/env.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: override ansible interpreter
+  set_fact:
+    ansible_python_interpreter: "{{ kubectl_python_interpreter }}"
+  when: kubectl_python_interpreter != ""
+
 - name: kubectl assume role
   community.aws.sts_assume_role:
     role_arn: "{{ kubectl_aws_role_arn }}"
@@ -28,11 +33,6 @@
       AWS_SESSION_TOKEN: "{{kubectl_aws_session_token}}"
       KUBECONFIG: "{{kubectl_config_path}}"
       K8S_AUTH_KUBECONFIG: "{{kubectl_config_path}}"
-
-- name: override ansible interpreter
-  set_fact:
-    ansible_python_interpreter: "{{ kubectl_python_interpreter }}"
-  when: kubectl_python_interpreter != ""
 
 - name: Configure kubectl for EKS
   command:


### PR DESCRIPTION
This moves the venv setup task in the `kubectl` role earlier to support the optional assume role task.  The default value of the interpreter is set to the mars venv location.