### PR TITLE
feat: add GCP support with gcloud CLI and credential mounting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | gpg --d
 RUN echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /" | tee /tmp/sources.list.d/kubernetes.list
 RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /tmp/keyrings/hashicorp-apt-keyring.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/hashicorp-apt-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /tmp/sources.list.d/hashicorp.list
+RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /tmp/keyrings/google-cloud-apt-keyring.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/google-cloud-apt-keyring.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee /tmp/sources.list.d/google-cloud-sdk.list
 
 COPY aws-cli-pkg-key.asc /tmp/aws-cli-pkg-key.asc
 RUN gpg --import /tmp/aws-cli-pkg-key.asc
@@ -92,7 +94,8 @@ COPY --from=downloader /tmp/keyrings /etc/apt/keyrings
 COPY --from=downloader /tmp/sources.list.d /etc/apt/sources.list.d
 RUN apt update -y && apt install --no-install-recommends -yq \
   kubectl \
-  packer
+  packer \
+  google-cloud-cli
 
 COPY --from=venv /opt/mars_venv /opt/mars_venv
 ENV PATH="/opt/mars_venv/bin:${PATH}"

--- a/mars_macos.sh
+++ b/mars_macos.sh
@@ -129,6 +129,7 @@ docker run --rm $DOCKER_TERM_VARS \
 	-v "$TF_PLUGIN_CACHE_DIR:/opt/tf-plugin-cache-dir" \
 	-v "$HOME/.aws/:/opt/home/.aws" \
 	-v "$HOME/.azure/:/opt/home/.azure" \
+	-v "$HOME/.config/gcloud/:/opt/home/.config/gcloud" \
 	-v "$PROJECT_PATH:$DOCKER_PROJECT_PATH" \
 	-w "$DOCKER_WORK_DIR" \
 	-e ANSIBLE_LOAD_CALLBACK_PLUGINS=yes \


### PR DESCRIPTION
## Summary

- Add Google Cloud apt repository and install `google-cloud-cli` in Dockerfile
- Mount `~/.config/gcloud/` in `mars_macos.sh` for local GCP credential access
- Enables Terraform deployments to GCP alongside existing AWS/Azure support

## Changes

### Dockerfile
- Added Google Cloud apt keyring and repository in the `downloader` stage
- Added `google-cloud-cli` package to the final stage apt install

### mars_macos.sh
- Added volume mount for `~/.config/gcloud/` to `/opt/home/.config/gcloud`

## Testing

Verified locally:
- `gcloud version` works in container (Google Cloud SDK 552.0.0)
- GCP credentials are properly mounted from host
- `gcloud auth list` shows authenticated accounts
- `terraform init` downloads Google provider successfully
- `terraform plan` authenticates with GCP and reads project data

## Consumer Usage

### Local Development (macOS)

1. Authenticate with GCP:
   ```bash
   gcloud auth login
   gcloud auth application-default login
   ```

2. Run mars commands as usual - credentials are automatically available

### Argo Workflows

For custom-stack deployments, set `GOOGLE_APPLICATION_CREDENTIALS` environment variable pointing to a decoded service account JSON file.

## Backward Compatibility

- AWS workflows continue to work unchanged
- Azure workflows continue to work unchanged
- No changes to Python scripts or Ansible roles