### PR TITLE
fix: bump cryptography from 42.0.8 to 46.0.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -359,7 +359,7 @@ certifi==2024.7.4
     #   kubernetes
     #   msrest
     #   requests
-cffi==1.16.0
+cffi==2.0.0
     # via
     #   azure-datalake-store
     #   cryptography

--- a/requirements.txt
+++ b/requirements.txt
@@ -370,7 +370,7 @@ charset-normalizer==3.3.2
     # via requests
 colorama==0.4.6
     # via azure-cli
-cryptography==42.0.8
+cryptography==46.0.6
     # via
     #   adal
     #   ansible-core


### PR DESCRIPTION
## Summary

Bump `cryptography` to the lowest non-vulnerable version (46.0.6). Dependabot couldn't auto-resolve this due to version constraint conflicts.

## Test plan

- [ ] CI passes (pip install succeeds with new version)