### PR TITLE
fix: patch kubernetes.core.helm for Helm v4 --all flag removal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,12 +108,14 @@ WORKDIR /marsproject
 COPY ansible-reqs.yml /opt/mars/ansible-reqs.yml
 RUN ansible-galaxy install -r /opt/mars/ansible-reqs.yml
 
-# Patch kubernetes.core.helm module for Helm v4 compatibility:
-# Helm 4 removed --all from "helm list" (all statuses shown by default).
-# kubernetes.core 5.4.2 doesn't have the fix yet (only on unreleased main).
-# Remove this patch when upgrading to a kubernetes.core version with is_helm_v4().
-RUN HELM_MODULE=$(find /opt/mars_venv -path "*/kubernetes/core/plugins/modules/helm.py" -o -path "*/ansible_collections/kubernetes/core/plugins/modules/helm.py" | head -1) && \
-    sed -i 's/list_command.append("--all")/pass  # --all removed in Helm v4 (default behavior)/' "$HELM_MODULE"
+# Patch kubernetes.core for Helm v4 compatibility (kubernetes.core 5.4.2 lacks support).
+# These patches match fixes in upstream PR #1090 (merged to main, not yet released).
+# Remove when upgrading to a kubernetes.core release with Helm v4 support.
+RUN K8S_CORE=$(find / -type d -path "*/ansible_collections/kubernetes/core" 2>/dev/null | head -1) && \
+    # 1. Remove --all from "helm list" (removed in Helm 4, now default behavior) \
+    sed -i 's/list_command.append("--all")/pass  # --all removed in Helm v4/' "$K8S_CORE/plugins/modules/helm.py" && \
+    # 2. Remove version check that rejects Helm >=4.0.0 \
+    sed -i 's/LooseVersion(helm_version) >= LooseVersion("4.0.0")/False/' "$K8S_CORE/plugins/module_utils/helm.py"
 
 COPY --from=downloader /tmp/tfedit /opt/bin/tfedit
 COPY --from=downloader /tmp/tfmigrate /opt/bin/tfmigrate

--- a/Dockerfile
+++ b/Dockerfile
@@ -111,11 +111,12 @@ RUN ansible-galaxy install -r /opt/mars/ansible-reqs.yml
 # Patch kubernetes.core for Helm v4 compatibility (kubernetes.core 5.4.2 lacks support).
 # These patches match fixes in upstream PR #1090 (merged to main, not yet released).
 # Remove when upgrading to a kubernetes.core release with Helm v4 support.
-RUN K8S_CORE=$(find / -type d -path "*/ansible_collections/kubernetes/core" 2>/dev/null | head -1) && \
-    # 1. Remove --all from "helm list" (removed in Helm 4, now default behavior) \
-    sed -i 's/list_command.append("--all")/pass  # --all removed in Helm v4/' "$K8S_CORE/plugins/modules/helm.py" && \
-    # 2. Remove version check that rejects Helm >=4.0.0 \
-    sed -i 's/LooseVersion(helm_version) >= LooseVersion("4.0.0")/False/' "$K8S_CORE/plugins/module_utils/helm.py"
+RUN find / -type d -path "*/ansible_collections/kubernetes/core" 2>/dev/null | while read K8S_CORE; do \
+      # 1. Remove --all from "helm list" (removed in Helm 4, now default behavior) \
+      sed -i 's/list_command.append("--all")/pass  # --all removed in Helm v4/' "$K8S_CORE/plugins/modules/helm.py" && \
+      # 2. Remove version check that rejects Helm >=4.0.0 \
+      sed -i 's/LooseVersion(helm_version) >= LooseVersion("4.0.0")/False/' "$K8S_CORE/plugins/module_utils/helm.py"; \
+    done
 
 COPY --from=downloader /tmp/tfedit /opt/bin/tfedit
 COPY --from=downloader /tmp/tfmigrate /opt/bin/tfmigrate

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,13 @@ WORKDIR /marsproject
 COPY ansible-reqs.yml /opt/mars/ansible-reqs.yml
 RUN ansible-galaxy install -r /opt/mars/ansible-reqs.yml
 
+# Patch kubernetes.core.helm module for Helm v4 compatibility:
+# Helm 4 removed --all from "helm list" (all statuses shown by default).
+# kubernetes.core 5.4.2 doesn't have the fix yet (only on unreleased main).
+# Remove this patch when upgrading to a kubernetes.core version with is_helm_v4().
+RUN HELM_MODULE=$(find /opt/mars_venv -path "*/kubernetes/core/plugins/modules/helm.py" -o -path "*/ansible_collections/kubernetes/core/plugins/modules/helm.py" | head -1) && \
+    sed -i 's/list_command.append("--all")/pass  # --all removed in Helm v4 (default behavior)/' "$HELM_MODULE"
+
 COPY --from=downloader /tmp/tfedit /opt/bin/tfedit
 COPY --from=downloader /tmp/tfmigrate /opt/bin/tfmigrate
 COPY --from=downloader /tmp/awscliv2.zip /tmp/awscliv2.zip

--- a/ansible-roles/k8s_fabric_ca/tasks/main.yml
+++ b/ansible-roles/k8s_fabric_ca/tasks/main.yml
@@ -66,7 +66,7 @@
         crypto-config.zip: "{{k8s_fabric_ca_crypto_config}}"
   no_log: True
   environment: "{{ kubectl_env }}"
-  when: k8s_fabric_ca_crypto_config
+  when: k8s_fabric_ca_crypto_config | default('') | length > 0
 
 - name: Helm Chart is installed
   kubernetes.core.helm:

--- a/ansible-roles/k8s_fabric_chaincode/tasks/main.yml
+++ b/ansible-roles/k8s_fabric_chaincode/tasks/main.yml
@@ -113,7 +113,7 @@
     extra_env_vars:
       FABRIC_DOMAIN: "{{k8s_fabric_chaincode_domain_root}}"
   environment: "{{ kubectl_env | combine(extra_env_vars) }}"
-  when: not committed
+  when: not committed | bool
   # TODO: only approve on luther orgs!
   loop: "{{ k8s_fabric_chaincode_orgs }}"
   register: approve_result
@@ -135,7 +135,7 @@
     extra_env_vars:
       FABRIC_DOMAIN: "{{k8s_fabric_chaincode_domain_root}}"
   environment: "{{ kubectl_env | combine(extra_env_vars) }}"
-  when: not committed
+  when: not committed | bool
   register: approval_script
   tags:
     - prepare_chaincode_upgrade
@@ -154,7 +154,7 @@
     extra_env_vars:
       FABRIC_DOMAIN: "{{k8s_fabric_chaincode_domain_root}}"
   environment: "{{ kubectl_env | combine(extra_env_vars) }}"
-  when: not committed
+  when: not committed | bool
   ignore_errors: true
   register: readiness_report
   changed_when: false
@@ -166,7 +166,7 @@
     msg:
       - "{{readiness_report.stdout}}"
       - "{{approval_script.stdout}}"
-  when: not committed
+  when: not committed | bool
   loop: "{{ k8s_fabric_chaincode_orgs }}"
   tags:
     - prepare_chaincode_upgrade
@@ -212,7 +212,7 @@
     extra_env_vars:
       FABRIC_DOMAIN: "{{k8s_fabric_chaincode_domain_root}}"
   environment: "{{ kubectl_env | combine(extra_env_vars) }}"
-  when: not committed
+  when: not committed | bool
   register: commit_result
 
 - name: Wait for chaincode commit
@@ -227,7 +227,7 @@
     extra_env_vars:
       FABRIC_DOMAIN: "{{k8s_fabric_chaincode_domain_root}}"
   environment: "{{ kubectl_env | combine(extra_env_vars) }}"
-  when: not committed
+  when: not committed | bool
   register: query_result
   until: query_result is succeeded
   retries: 5

--- a/ansible-roles/k8s_fabric_cli/tasks/main.yml
+++ b/ansible-roles/k8s_fabric_cli/tasks/main.yml
@@ -22,7 +22,7 @@
         crypto-config.zip: "{{k8s_fabric_cli_crypto_config}}"
   no_log: True
   environment: "{{ kubectl_env }}"
-  when: k8s_fabric_cli_crypto_config
+  when: k8s_fabric_cli_crypto_config | default('') | length > 0
 
 - name: Fabric channel-artifacts configmap exists
   k8s:
@@ -35,7 +35,7 @@
       binaryData:
         channel-artifacts.zip: "{{k8s_fabric_cli_channel_artifacts}}"
   environment: "{{ kubectl_env }}"
-  when: k8s_fabric_cli_channel_artifacts
+  when: k8s_fabric_cli_channel_artifacts | default('') | length > 0
 
 - name: Fabric collections configmap exists
   k8s:
@@ -48,7 +48,7 @@
       binaryData:
         collections.json: "{{k8s_fabric_cli_collections}}"
   environment: "{{ kubectl_env }}"
-  when: k8s_fabric_cli_collections
+  when: k8s_fabric_cli_collections | default('') | length > 0
 
 - name: Create Fabric CLI Service Accounts
   k8s:

--- a/ansible-roles/k8s_fabric_orderer/tasks/main.yml
+++ b/ansible-roles/k8s_fabric_orderer/tasks/main.yml
@@ -29,7 +29,7 @@
         crypto-config.zip: "{{k8s_fabric_orderer_crypto_config}}"
   no_log: True
   environment: "{{ kubectl_env }}"
-  when: k8s_fabric_orderer_crypto_config
+  when: k8s_fabric_orderer_crypto_config | default('') | length > 0
 
 - name: Fabric channel-artifacts configmap exists
   k8s:
@@ -42,7 +42,7 @@
       binaryData:
         channel-artifacts.zip: "{{k8s_fabric_orderer_channel_artifacts}}"
   environment: "{{ kubectl_env }}"
-  when: k8s_fabric_orderer_channel_artifacts
+  when: k8s_fabric_orderer_channel_artifacts | default('') | length > 0
 
 - name: Create Orderer Peer Service Accounts
   k8s:

--- a/ansible-roles/k8s_fabric_peer/tasks/main.yml
+++ b/ansible-roles/k8s_fabric_peer/tasks/main.yml
@@ -44,7 +44,7 @@
         crypto-config.zip: "{{k8s_fabric_peer_crypto_config}}"
   no_log: True
   environment: "{{ kubectl_env }}"
-  when: k8s_fabric_peer_crypto_config
+  when: k8s_fabric_peer_crypto_config | default('') | length > 0
 
 - name: Create Fabric Peer Service Accounts
   k8s:

--- a/mars_macos.sh
+++ b/mars_macos.sh
@@ -132,8 +132,8 @@ docker run --rm $DOCKER_TERM_VARS \
 	-v "$HOME/.config/gcloud/:/opt/home/.config/gcloud" \
 	-v "$PROJECT_PATH:$DOCKER_PROJECT_PATH" \
 	-w "$DOCKER_WORK_DIR" \
-	-e ANSIBLE_LOAD_CALLBACK_PLUGINS=yes \
-	-e ANSIBLE_STDOUT_CALLBACK=yaml \
+	-e ANSIBLE_STDOUT_CALLBACK=ansible.builtin.default \
+	-e ANSIBLE_CALLBACK_RESULT_FORMAT=yaml \
         $LOCAL_OPTS \
         $NETWORK_OPTS \
 	$SHELL_OPTS \

--- a/requirements.txt
+++ b/requirements.txt
@@ -359,7 +359,7 @@ certifi==2024.7.4
     #   kubernetes
     #   msrest
     #   requests
-cffi==1.16.0
+cffi==2.0.0
     # via
     #   azure-datalake-store
     #   cryptography
@@ -370,7 +370,7 @@ charset-normalizer==3.3.2
     # via requests
 colorama==0.4.6
     # via azure-cli
-cryptography==42.0.8
+cryptography==46.0.6
     # via
     #   adal
     #   ansible-core

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,37 +4,35 @@
 #
 #    pip-compile requirements.in
 #
-adal==1.2.7
-    # via msrestazure
-ansible==12.2.0
+ansible==13.5.0
     # via -r requirements.in
-ansible-core==2.19.4
+ansible-core==2.20.4
     # via ansible
-antlr4-python3-runtime==4.13.1
+antlr4-python3-runtime==4.13.2
     # via azure-cli
 applicationinsights==0.11.10
     # via azure-cli-telemetry
-argcomplete==3.3.0
+argcomplete==3.5.3
     # via
     #   azure-cli-core
     #   knack
-azure-appconfiguration==1.1.1
+azure-ai-agents==1.1.0
+    # via azure-ai-projects
+azure-ai-projects==1.0.0
     # via azure-cli
-azure-batch==14.2.0
+azure-appconfiguration==1.7.2
     # via azure-cli
-azure-cli==2.61.0
+azure-batch==15.0.0b1
+    # via azure-cli
+azure-cli==2.84.0
     # via -r requirements.in
-azure-cli-core==2.61.0
+azure-cli-core==2.84.0
     # via azure-cli
 azure-cli-telemetry==1.1.0
     # via azure-cli-core
 azure-common==1.1.28
     # via
-    #   azure-batch
-    #   azure-graphrbac
-    #   azure-keyvault-administration
     #   azure-keyvault-certificates
-    #   azure-keyvault-keys
     #   azure-keyvault-secrets
     #   azure-mgmt-advisor
     #   azure-mgmt-apimanagement
@@ -47,29 +45,19 @@ azure-common==1.1.28
     #   azure-mgmt-billing
     #   azure-mgmt-botservice
     #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
     #   azure-mgmt-compute
     #   azure-mgmt-containerinstance
     #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-databoxedge
     #   azure-mgmt-datalake-store
     #   azure-mgmt-datamigration
-    #   azure-mgmt-devtestlabs
-    #   azure-mgmt-dns
     #   azure-mgmt-eventgrid
     #   azure-mgmt-eventhub
     #   azure-mgmt-extendedlocation
-    #   azure-mgmt-hdinsight
     #   azure-mgmt-imagebuilder
     #   azure-mgmt-iotcentral
     #   azure-mgmt-iothub
     #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-kusto
     #   azure-mgmt-loganalytics
-    #   azure-mgmt-managedservices
     #   azure-mgmt-managementgroups
     #   azure-mgmt-maps
     #   azure-mgmt-marketplaceordering
@@ -80,11 +68,12 @@ azure-common==1.1.28
     #   azure-mgmt-policyinsights
     #   azure-mgmt-privatedns
     #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
     #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redhatopenshift
     #   azure-mgmt-redis
     #   azure-mgmt-resource
+    #   azure-mgmt-resource-deployments
+    #   azure-mgmt-resource-deploymentscripts
+    #   azure-mgmt-resource-templatespecs
     #   azure-mgmt-search
     #   azure-mgmt-security
     #   azure-mgmt-servicebus
@@ -94,28 +83,34 @@ azure-common==1.1.28
     #   azure-mgmt-signalr
     #   azure-mgmt-sql
     #   azure-mgmt-sqlvirtualmachine
-    #   azure-mgmt-storage
     #   azure-mgmt-synapse
     #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-    #   azure-multiapi-storage
     #   azure-storage-common
     #   azure-synapse-accesscontrol
     #   azure-synapse-artifacts
     #   azure-synapse-managedprivateendpoints
     #   azure-synapse-spark
-azure-core==1.38.0
+azure-core==1.38.3
     # via
+    #   azure-ai-agents
+    #   azure-ai-projects
     #   azure-appconfiguration
+    #   azure-batch
+    #   azure-cli-core
     #   azure-data-tables
     #   azure-identity
     #   azure-keyvault-administration
     #   azure-keyvault-certificates
     #   azure-keyvault-keys
     #   azure-keyvault-secrets
+    #   azure-keyvault-securitydomain
     #   azure-mgmt-core
     #   azure-monitor-query
-    #   azure-multiapi-storage
+    #   azure-storage-blob
+    #   azure-storage-file-datalake
+    #   azure-storage-file-share
+    #   azure-storage-queue
     #   azure-synapse-accesscontrol
     #   azure-synapse-managedprivateendpoints
     #   azure-synapse-spark
@@ -124,31 +119,31 @@ azure-cosmos==3.2.0
     # via azure-cli
 azure-data-tables==12.4.0
     # via azure-cli
-azure-datalake-store==0.0.53
+azure-datalake-store==1.0.1
     # via azure-cli
-azure-graphrbac==0.60.0
-    # via azure-cli
-azure-identity==1.16.1
+azure-identity==1.25.2
     # via -r requirements.in
-azure-keyvault-administration==4.4.0b2
+azure-keyvault-administration==4.4.0
     # via azure-cli
 azure-keyvault-certificates==4.7.0
     # via azure-cli
-azure-keyvault-keys==4.9.0b3
+azure-keyvault-keys==4.11.0
     # via azure-cli
 azure-keyvault-secrets==4.7.0
+    # via azure-cli
+azure-keyvault-securitydomain==1.0.0b1
     # via azure-cli
 azure-mgmt-advisor==9.0.0
     # via azure-cli
 azure-mgmt-apimanagement==4.0.0
     # via azure-cli
-azure-mgmt-appconfiguration==3.0.0
+azure-mgmt-appconfiguration==5.0.0
     # via azure-cli
 azure-mgmt-appcontainers==2.0.0
     # via azure-cli
 azure-mgmt-applicationinsights==1.0.0
     # via azure-cli
-azure-mgmt-authorization==4.0.0
+azure-mgmt-authorization==5.0.0b1
     # via azure-cli
 azure-mgmt-batch==17.3.0
     # via azure-cli
@@ -160,17 +155,17 @@ azure-mgmt-botservice==2.0.0
     # via azure-cli
 azure-mgmt-cdn==12.0.0
     # via azure-cli
-azure-mgmt-cognitiveservices==13.5.0
+azure-mgmt-cognitiveservices==14.1.0
     # via azure-cli
-azure-mgmt-compute==31.0.0
+azure-mgmt-compute==34.1.0
     # via azure-cli
-azure-mgmt-containerinstance==10.1.0
+azure-mgmt-containerinstance==10.2.0b1
     # via azure-cli
-azure-mgmt-containerregistry==10.3.0
+azure-mgmt-containerregistry==14.1.0b1
     # via azure-cli
-azure-mgmt-containerservice==30.0.0
+azure-mgmt-containerservice==40.2.0
     # via azure-cli
-azure-mgmt-core==1.4.0
+azure-mgmt-core==1.6.0
     # via
     #   azure-cli-core
     #   azure-mgmt-advisor
@@ -190,9 +185,8 @@ azure-mgmt-core==1.4.0
     #   azure-mgmt-containerregistry
     #   azure-mgmt-containerservice
     #   azure-mgmt-cosmosdb
-    #   azure-mgmt-databoxedge
+    #   azure-mgmt-datalake-store
     #   azure-mgmt-datamigration
-    #   azure-mgmt-dns
     #   azure-mgmt-eventgrid
     #   azure-mgmt-eventhub
     #   azure-mgmt-extendedlocation
@@ -209,8 +203,10 @@ azure-mgmt-core==1.4.0
     #   azure-mgmt-media
     #   azure-mgmt-monitor
     #   azure-mgmt-msi
+    #   azure-mgmt-mysqlflexibleservers
     #   azure-mgmt-netapp
     #   azure-mgmt-policyinsights
+    #   azure-mgmt-postgresqlflexibleservers
     #   azure-mgmt-privatedns
     #   azure-mgmt-rdbms
     #   azure-mgmt-recoveryservices
@@ -218,6 +214,10 @@ azure-mgmt-core==1.4.0
     #   azure-mgmt-redhatopenshift
     #   azure-mgmt-redis
     #   azure-mgmt-resource
+    #   azure-mgmt-resource-deployments
+    #   azure-mgmt-resource-deploymentscripts
+    #   azure-mgmt-resource-deploymentstacks
+    #   azure-mgmt-resource-templatespecs
     #   azure-mgmt-search
     #   azure-mgmt-security
     #   azure-mgmt-servicebus
@@ -232,43 +232,31 @@ azure-mgmt-core==1.4.0
     #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
     #   azure-synapse-artifacts
-azure-mgmt-cosmosdb==9.4.0
+azure-mgmt-cosmosdb==9.9.0
     # via azure-cli
-azure-mgmt-databoxedge==1.0.0
-    # via azure-cli
-azure-mgmt-datalake-nspkg==3.0.1
-    # via azure-mgmt-datalake-store
-azure-mgmt-datalake-store==0.5.0
+azure-mgmt-datalake-store==1.1.0b1
     # via azure-cli
 azure-mgmt-datamigration==10.0.0
     # via azure-cli
-azure-mgmt-devtestlabs==4.0.0
-    # via azure-cli
-azure-mgmt-dns==8.0.0
-    # via azure-cli
 azure-mgmt-eventgrid==10.2.0b2
     # via azure-cli
-azure-mgmt-eventhub==10.1.0
+azure-mgmt-eventhub==12.0.0b1
     # via azure-cli
 azure-mgmt-extendedlocation==1.0.0b2
     # via azure-cli
-azure-mgmt-hdinsight==9.0.0
+azure-mgmt-hdinsight==9.1.0b2
     # via azure-cli
 azure-mgmt-imagebuilder==1.3.0
     # via azure-cli
 azure-mgmt-iotcentral==10.0.0b2
     # via azure-cli
-azure-mgmt-iothub==3.0.0
+azure-mgmt-iothub==5.0.0b1
     # via azure-cli
 azure-mgmt-iothubprovisioningservices==1.1.0
     # via azure-cli
-azure-mgmt-keyvault==10.3.0
-    # via azure-cli
-azure-mgmt-kusto==0.3.0
+azure-mgmt-keyvault==13.0.0
     # via azure-cli
 azure-mgmt-loganalytics==13.0.0b4
-    # via azure-cli
-azure-mgmt-managedservices==1.0.0
     # via azure-cli
 azure-mgmt-managementgroups==1.0.0
     # via azure-cli
@@ -278,83 +266,98 @@ azure-mgmt-marketplaceordering==1.1.0
     # via azure-cli
 azure-mgmt-media==9.0.0
     # via azure-cli
-azure-mgmt-monitor==5.0.1
+azure-mgmt-monitor==7.0.0
     # via azure-cli
-azure-mgmt-msi==7.0.0
+azure-mgmt-msi==7.1.0
+    # via azure-cli
+azure-mgmt-mysqlflexibleservers==1.1.0b2
     # via azure-cli
 azure-mgmt-netapp==10.1.0
     # via azure-cli
-azure-mgmt-nspkg==3.0.2
-    # via azure-mgmt-datalake-nspkg
 azure-mgmt-policyinsights==1.1.0b4
+    # via azure-cli
+azure-mgmt-postgresqlflexibleservers==3.0.0b1
     # via azure-cli
 azure-mgmt-privatedns==1.0.0
     # via azure-cli
 azure-mgmt-rdbms==10.2.0b17
     # via azure-cli
-azure-mgmt-recoveryservices==3.0.0
+azure-mgmt-recoveryservices==4.0.0
     # via azure-cli
-azure-mgmt-recoveryservicesbackup==9.1.0
+azure-mgmt-recoveryservicesbackup==9.2.0
     # via azure-cli
-azure-mgmt-redhatopenshift==1.4.0
+azure-mgmt-redhatopenshift==3.0.0
     # via azure-cli
-azure-mgmt-redis==14.3.0
+azure-mgmt-redis==14.5.0
     # via azure-cli
-azure-mgmt-resource==23.1.1
+azure-mgmt-resource==24.0.0
     # via azure-cli
-azure-mgmt-search==9.1.0
+azure-mgmt-resource-deployments==1.0.0b1
+    # via azure-cli
+azure-mgmt-resource-deploymentscripts==1.0.0b1
+    # via azure-cli
+azure-mgmt-resource-deploymentstacks==1.0.0
+    # via azure-cli
+azure-mgmt-resource-templatespecs==1.0.0b1
+    # via azure-cli
+azure-mgmt-search==9.2.0
     # via azure-cli
 azure-mgmt-security==6.0.0
     # via azure-cli
-azure-mgmt-servicebus==8.2.0
+azure-mgmt-servicebus==10.0.0b1
     # via azure-cli
 azure-mgmt-servicefabric==2.1.0
     # via azure-cli
-azure-mgmt-servicefabricmanagedclusters==2.0.0b6
+azure-mgmt-servicefabricmanagedclusters==2.1.0b1
     # via azure-cli
-azure-mgmt-servicelinker==1.2.0b2
+azure-mgmt-servicelinker==1.2.0b3
     # via azure-cli
-azure-mgmt-signalr==2.0.0b1
+azure-mgmt-signalr==2.0.0b2
     # via azure-cli
-azure-mgmt-sql==4.0.0b16
+azure-mgmt-sql==4.0.0b22
     # via azure-cli
 azure-mgmt-sqlvirtualmachine==1.0.0b5
     # via azure-cli
-azure-mgmt-storage==21.1.0
+azure-mgmt-storage==24.0.0
     # via azure-cli
 azure-mgmt-synapse==2.1.0b5
     # via azure-cli
 azure-mgmt-trafficmanager==1.0.0
     # via azure-cli
-azure-mgmt-web==7.2.0
+azure-mgmt-web==9.0.0
     # via azure-cli
 azure-monitor-query==1.2.0
     # via azure-cli
-azure-multiapi-storage==1.2.0
-    # via azure-cli
-azure-nspkg==3.0.2
-    # via azure-mgmt-nspkg
+azure-storage-blob==12.28.0b1
+    # via
+    #   azure-ai-projects
+    #   azure-cli
+    #   azure-storage-file-datalake
 azure-storage-common==1.4.2
+    # via azure-cli
+azure-storage-file-datalake==12.23.0b1
+    # via azure-cli
+azure-storage-file-share==12.24.0b1
+    # via azure-cli
+azure-storage-queue==12.15.0b1
     # via azure-cli
 azure-synapse-accesscontrol==0.5.0
     # via azure-cli
-azure-synapse-artifacts==0.18.0
+azure-synapse-artifacts==0.21.0
     # via azure-cli
 azure-synapse-managedprivateendpoints==0.4.0
     # via azure-cli
-azure-synapse-spark==0.2.0
+azure-synapse-spark==0.7.0
     # via azure-cli
-bcrypt==4.1.3
+bcrypt==5.0.0
     # via paramiko
-boto3==1.34.125
+boto3==1.42.82
     # via -r requirements.in
-botocore==1.34.125
+botocore==1.42.82
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.3
-    # via google-auth
-certifi==2024.7.4
+certifi==2026.2.25
     # via
     #   kubernetes
     #   msrest
@@ -366,26 +369,27 @@ cffi==2.0.0
     #   pynacl
 chardet==5.2.0
     # via azure-cli
-charset-normalizer==3.3.2
+charset-normalizer==3.4.7
     # via requests
 colorama==0.4.6
     # via azure-cli
 cryptography==46.0.6
     # via
-    #   adal
     #   ansible-core
     #   azure-cli-core
     #   azure-identity
     #   azure-keyvault-keys
-    #   azure-multiapi-storage
+    #   azure-storage-blob
     #   azure-storage-common
+    #   azure-storage-file-share
+    #   azure-storage-queue
     #   msal
     #   paramiko
     #   pyjwt
     #   pyopenssl
-decorator==5.1.1
+decorator==5.2.1
     # via fabric
-deprecated==1.2.14
+deprecated==1.3.1
     # via
     #   fabric
     #   pygithub
@@ -393,59 +397,74 @@ distro==1.9.0
     # via
     #   azure-cli
     #   azure-cli-core
+durationpy==0.10
+    # via kubernetes
 fabric==3.2.2
     # via azure-cli
-google-auth==2.30.0
-    # via kubernetes
 humanfriendly==10.0
     # via azure-cli-core
-idna==3.7
+idna==3.11
     # via requests
-invoke==2.2.0
+invoke==2.2.1
     # via fabric
-isodate==0.6.1
+isodate==0.7.2
     # via
+    #   azure-ai-agents
+    #   azure-ai-projects
+    #   azure-appconfiguration
+    #   azure-batch
     #   azure-keyvault-administration
     #   azure-keyvault-certificates
     #   azure-keyvault-keys
     #   azure-keyvault-secrets
+    #   azure-keyvault-securitydomain
     #   azure-mgmt-apimanagement
     #   azure-mgmt-appconfiguration
     #   azure-mgmt-authorization
     #   azure-mgmt-batch
-    #   azure-mgmt-cognitiveservices
     #   azure-mgmt-compute
     #   azure-mgmt-containerinstance
     #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
+    #   azure-mgmt-eventhub
     #   azure-mgmt-imagebuilder
     #   azure-mgmt-iothub
     #   azure-mgmt-keyvault
+    #   azure-mgmt-monitor
+    #   azure-mgmt-msi
+    #   azure-mgmt-mysqlflexibleservers
     #   azure-mgmt-netapp
+    #   azure-mgmt-postgresqlflexibleservers
     #   azure-mgmt-rdbms
     #   azure-mgmt-recoveryservices
     #   azure-mgmt-recoveryservicesbackup
     #   azure-mgmt-redhatopenshift
     #   azure-mgmt-redis
     #   azure-mgmt-resource
+    #   azure-mgmt-resource-deployments
+    #   azure-mgmt-resource-deploymentscripts
+    #   azure-mgmt-resource-deploymentstacks
+    #   azure-mgmt-resource-templatespecs
     #   azure-mgmt-search
     #   azure-mgmt-security
+    #   azure-mgmt-servicebus
     #   azure-mgmt-servicefabric
     #   azure-mgmt-servicefabricmanagedclusters
     #   azure-mgmt-servicelinker
     #   azure-mgmt-signalr
     #   azure-mgmt-sql
-    #   azure-mgmt-storage
     #   azure-mgmt-web
     #   azure-monitor-query
+    #   azure-storage-blob
+    #   azure-storage-file-datalake
+    #   azure-storage-file-share
+    #   azure-storage-queue
     #   azure-synapse-artifacts
     #   msrest
 javaproperties==0.5.2
     # via azure-cli
-jinja2==3.1.5
+jinja2==3.1.6
     # via ansible-core
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   azure-cli-core
     #   boto3
@@ -455,25 +474,24 @@ jsondiff==2.0.0
     # via azure-cli
 knack==0.11.0
     # via azure-cli-core
-kubernetes==30.1.0
+kubernetes==35.0.0
     # via -r requirements.in
-markupsafe==2.1.5
+markupsafe==3.0.3
     # via jinja2
-msal[broker]==1.28.0
+microsoft-security-utilities-secret-masker==1.0.0b4
+    # via azure-cli-core
+msal==1.35.0b1
     # via
     #   azure-cli-core
-    #   azure-datalake-store
     #   azure-identity
     #   msal-extensions
-msal-extensions==1.2.0b1
+msal-extensions==1.2.0
     # via
     #   azure-cli-core
     #   azure-identity
 msrest==0.7.1
     # via
-    #   azure-appconfiguration
     #   azure-data-tables
-    #   azure-graphrbac
     #   azure-mgmt-advisor
     #   azure-mgmt-appcontainers
     #   azure-mgmt-applicationinsights
@@ -481,122 +499,96 @@ msrest==0.7.1
     #   azure-mgmt-billing
     #   azure-mgmt-botservice
     #   azure-mgmt-cdn
-    #   azure-mgmt-databoxedge
+    #   azure-mgmt-cognitiveservices
+    #   azure-mgmt-containerservice
+    #   azure-mgmt-cosmosdb
+    #   azure-mgmt-datalake-store
     #   azure-mgmt-datamigration
-    #   azure-mgmt-devtestlabs
-    #   azure-mgmt-dns
     #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
     #   azure-mgmt-extendedlocation
     #   azure-mgmt-hdinsight
     #   azure-mgmt-iotcentral
     #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-kusto
     #   azure-mgmt-loganalytics
-    #   azure-mgmt-managedservices
     #   azure-mgmt-managementgroups
     #   azure-mgmt-maps
     #   azure-mgmt-marketplaceordering
     #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-policyinsights
     #   azure-mgmt-privatedns
-    #   azure-mgmt-servicebus
     #   azure-mgmt-sqlvirtualmachine
+    #   azure-mgmt-storage
     #   azure-mgmt-synapse
     #   azure-mgmt-trafficmanager
-    #   azure-multiapi-storage
     #   azure-synapse-accesscontrol
     #   azure-synapse-managedprivateendpoints
     #   azure-synapse-spark
-    #   msrestazure
-msrestazure==0.6.4.post1
-    # via
-    #   azure-batch
-    #   azure-cli-core
-    #   azure-graphrbac
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-devtestlabs
-    #   azure-mgmt-kusto
-    #   azure-mgmt-managedservices
-oauthlib==3.2.2
-    # via
-    #   kubernetes
-    #   requests-oauthlib
-packaging==24.1
+oauthlib==3.3.1
+    # via requests-oauthlib
+packaging==26.0
     # via
     #   ansible-core
     #   azure-cli
     #   azure-cli-core
     #   knack
-paramiko==3.4.0
+paramiko==3.5.1
     # via
-    #   azure-cli-core
+    #   azure-cli
     #   fabric
     #   scp
     #   sshtunnel
-pkginfo==1.11.1
+pkginfo==1.12.1.2
     # via azure-cli-core
-portalocker==2.8.2
+portalocker==2.10.1
     # via
     #   azure-cli-telemetry
     #   msal-extensions
-psutil==5.9.8
+psutil==7.2.2
     # via azure-cli-core
-pyasn1==0.6.3
-    # via
-    #   pyasn1-modules
-    #   rsa
-pyasn1-modules==0.4.0
-    # via google-auth
-pycomposefile==0.0.31
+py-deviceid==0.1.1
+    # via azure-cli-core
+pycomposefile==0.0.34
     # via azure-cli
-pycparser==2.22
+pycparser==3.0
     # via cffi
 pygithub==1.59.1
     # via azure-cli
 pygments==2.20.0
     # via knack
-pyjwt[crypto]==2.12.0
+pyjwt[crypto]==2.12.1
     # via
-    #   adal
     #   azure-cli-core
     #   msal
     #   pygithub
-pynacl==1.5.0
+pynacl==1.6.2
     # via
     #   azure-cli
     #   paramiko
     #   pygithub
-pyopenssl==24.1.0
+pyopenssl==26.0.0
     # via azure-cli-core
 pysocks==1.7.1
     # via requests
 python-dateutil==2.9.0.post0
     # via
-    #   adal
-    #   azure-multiapi-storage
     #   azure-storage-common
     #   botocore
     #   kubernetes
-python-dotenv==1.0.1
+python-dotenv==1.2.2
     # via -r requirements.in
-pyyaml==6.0.1
+pyyaml==6.0.3
     # via
     #   ansible-core
     #   knack
     #   kubernetes
     #   pycomposefile
-requests[socks]==2.33.0
+requests[socks]==2.33.1
     # via
     #   -r requirements.in
-    #   adal
     #   azure-cli-core
     #   azure-core
     #   azure-cosmos
     #   azure-datalake-store
-    #   azure-multiapi-storage
     #   azure-storage-common
     #   kubernetes
     #   msal
@@ -607,50 +599,93 @@ requests-oauthlib==2.0.0
     # via
     #   kubernetes
     #   msrest
-resolvelib==1.0.1
+resolvelib==1.2.1
     # via ansible-core
-rsa==4.9
-    # via google-auth
-s3transfer==0.10.1
+s3transfer==0.16.0
     # via boto3
 scp==0.13.6
     # via azure-cli
-semver==2.13.0
+semver==3.0.4
     # via azure-cli
-six==1.16.0
+six==1.17.0
     # via
     #   azure-cli
     #   azure-cosmos
-    #   isodate
     #   javaproperties
     #   kubernetes
-    #   msrestazure
     #   python-dateutil
 sshtunnel==0.1.5
     # via azure-cli
-tabulate==0.9.0
+tabulate==0.10.0
     # via
     #   azure-cli
     #   knack
-typing-extensions==4.12.2
+typing-extensions==4.15.0
     # via
+    #   azure-ai-agents
+    #   azure-ai-projects
+    #   azure-appconfiguration
+    #   azure-batch
     #   azure-core
+    #   azure-identity
     #   azure-keyvault-administration
     #   azure-keyvault-certificates
     #   azure-keyvault-keys
     #   azure-keyvault-secrets
+    #   azure-keyvault-securitydomain
+    #   azure-mgmt-appconfiguration
+    #   azure-mgmt-authorization
+    #   azure-mgmt-cognitiveservices
+    #   azure-mgmt-compute
+    #   azure-mgmt-containerinstance
+    #   azure-mgmt-containerregistry
+    #   azure-mgmt-containerservice
+    #   azure-mgmt-cosmosdb
+    #   azure-mgmt-eventhub
+    #   azure-mgmt-hdinsight
+    #   azure-mgmt-iothub
+    #   azure-mgmt-keyvault
+    #   azure-mgmt-monitor
+    #   azure-mgmt-msi
+    #   azure-mgmt-mysqlflexibleservers
+    #   azure-mgmt-postgresqlflexibleservers
+    #   azure-mgmt-recoveryservices
+    #   azure-mgmt-recoveryservicesbackup
+    #   azure-mgmt-redhatopenshift
+    #   azure-mgmt-redis
+    #   azure-mgmt-resource
+    #   azure-mgmt-resource-deployments
+    #   azure-mgmt-resource-deploymentscripts
+    #   azure-mgmt-resource-deploymentstacks
+    #   azure-mgmt-resource-templatespecs
+    #   azure-mgmt-search
+    #   azure-mgmt-servicebus
+    #   azure-mgmt-servicefabricmanagedclusters
+    #   azure-mgmt-servicelinker
+    #   azure-mgmt-sql
+    #   azure-mgmt-storage
+    #   azure-mgmt-web
     #   azure-monitor-query
+    #   azure-storage-blob
+    #   azure-storage-file-datalake
+    #   azure-storage-file-share
+    #   azure-storage-queue
+    #   azure-synapse-artifacts
+    #   pyopenssl
 urllib3==2.6.3
     # via
     #   azure-cli
     #   botocore
     #   kubernetes
     #   requests
-websocket-client==1.3.3
+websocket-client==1.8.0
     # via
     #   azure-cli
     #   kubernetes
-wrapt==1.16.0
+wrapt==2.1.2
     # via deprecated
-xmltodict==0.13.0
+xmltodict==0.15.1
     # via azure-cli
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
## Summary

Helm 4 removed `--all` from `helm list` (all statuses shown by default). The `kubernetes.core.helm` module (5.4.2) unconditionally passes `--all` on every operation's final status check, causing **all** helm tasks to fail with `unknown flag: --all`.

No released version of `kubernetes.core` has the fix — it's only on unreleased `main`. This patches the installed module in the Docker image via `sed` until a release includes the `is_helm_v4()` guard.

Scanned all ansible roles — no other Helm v3-specific flags found.

## Test plan

- [ ] CI passes
- [ ] Tag SNAPSHOT and test helm install in ui-infrastructure
- [ ] Verify `kubernetes.core.helm` tasks succeed (install, upgrade, uninstall)