### PR TITLE
fix: ansible-vault-decrypt[-key] TypeError on Ansible 2.19+

### DIFF
--- a/scripts/luther_ansible.py
+++ b/scripts/luther_ansible.py
@@ -104,6 +104,13 @@ class Ansible(object):
         if any(az_vault_args) and not all(az_vault_args):
             raise Exception("--az-vault and --az-vault-key must be supplied together")
 
+        if not args.aws_sm_secret_id:
+            args.aws_sm_secret_id = os.environ.get("AWS_SM_SECRET_ID", "")
+        if not args.aws_region:
+            args.aws_region = os.environ.get("AWS_REGION", "")
+        if not args.aws_role_arn:
+            args.aws_role_arn = os.environ.get("AWS_ROLE_ARN", "")
+
         aws_sm_args = [args.aws_sm_secret_id, args.aws_region]
         if any(aws_sm_args) and not all(aws_sm_args):
             raise Exception(
@@ -206,16 +213,16 @@ class Ansible(object):
         if args.path:
             with open(args.path) as f:
                 encrypted = f.read()
-            self._vault_decrypt(encrypted, encryption_key, filename=args.path)
+            self._vault_decrypt(encrypted, encryption_key)
         else:
             if not stdin_pipe():
                 raise Exception("expected to read an encrypted secret from stdin")
             encrypted = sys.stdin.read().rstrip("\n")
             self._vault_decrypt(encrypted, encryption_key)
 
-    def _vault_decrypt(self, encrypted, encryption_key, filename=None):
+    def _vault_decrypt(self, encrypted, encryption_key):
         vault = vault_client(encryption_key)
-        secret = vault.decrypt(bytes(encrypted, "utf-8"), filename)
+        secret = vault.decrypt(bytes(encrypted, "utf-8"))
         print(secret.decode("utf-8"))
 
     def _read_inventory_config(self):


### PR DESCRIPTION
## Summary
- Drop the `filename` positional arg from `VaultLib.decrypt()` — Ansible 2.19+ removed it, so `mars <env> ansible-vault-decrypt[-key]` was raising `TypeError: VaultLib.decrypt() takes 2 positional arguments but 3 were given` on the current image. `VaultLib.decrypt(data)` (single positional) works on both 2.18 and 2.19+.
- Fall back to `AWS_SM_SECRET_ID` / `AWS_REGION` / `AWS_ROLE_ARN` env vars when the matching `--aws-sm-*` flags aren't supplied. Matches what `vault-aws-secretsmanager.py` already reads from env, so `source vars/<env>/vault-ref` is now sufficient on its own.
- Closes #129.

## Test plan
- [ ] Build the image: `make`.
- [ ] Round-trip with stdin (no real secret needed):
  ```bash
  source vars/<env>/vault-ref
  aws_admin
  echo -n "hello-129" | mars <env> ansible-vault-encrypt > /tmp/enc.txt
  cat /tmp/enc.txt | mars <env> ansible-vault-decrypt
  # expect: hello-129
  ```
- [ ] Reproduce the original failure path from the issue, without passing `--aws-sm-*` flags, to confirm the env fallback works:
  ```bash
  cd .../ui-infrastructure/ansible
  source vars/test/vault-ref
  bash ../mars test ansible-vault-decrypt-key \
    inventories/test/group_vars/all/auth0_client_secret.yaml auth0_client_secret
  # expect: secret printed; no TypeError, no "no remote vault key supplied"
  ```

## Review notes
- /review findings: 0 P0, 0 P1, 1 P2 (noted below), 1 P3 (out-of-scope).
- qa-professor: skipped — no test files changed (no python test suite in this repo).

### P2: env-var fallback also affects `ansible-playbook` / `ansible-execute`
The fallback runs post-parse in `Ansible.main()`, so it applies to every subparser that includes `vault_parser` — not just the explicit vault subcommands. A user with `AWS_SM_SECRET_ID` exported (e.g. via `source vars/<env>/vault-ref`) who previously fell through to the local `*_vault_password.txt` glob will now switch to the AWS SM vault plugin. This is consistent with the rest of the vault-ref usage pattern and with the fact that `vault-aws-secretsmanager.py` already reads the same env vars; calling it out so reviewers see it intentionally.