### PR TITLE
insideoutmcp chart: add gRPC port + service.annotations passthrough

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.tmp/

--- a/ansible-roles/helm_charts/files/helmcharts/insideoutmcp/templates/deployment.yaml
+++ b/ansible-roles/helm_charts/files/helmcharts/insideoutmcp/templates/deployment.yaml
@@ -42,6 +42,11 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            {{- if .Values.service.grpc.enabled }}
+            - name: grpc
+              containerPort: {{ .Values.service.grpc.targetPort }}
+              protocol: TCP
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/ansible-roles/helm_charts/files/helmcharts/insideoutmcp/templates/service.yaml
+++ b/ansible-roles/helm_charts/files/helmcharts/insideoutmcp/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "insideoutmcp.fullname" . }}
   labels:
     {{- include "insideoutmcp.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -11,6 +15,13 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.service.grpc.enabled }}
+    - port: {{ .Values.service.grpc.port }}
+      targetPort: {{ .Values.service.grpc.targetPort }}
+      protocol: TCP
+      name: grpc
+      appProtocol: grpc
+    {{- end }}
   selector:
     {{- include "insideoutmcp.labels.match" . | nindent 4 }}
 

--- a/ansible-roles/helm_charts/files/helmcharts/insideoutmcp/values.yaml
+++ b/ansible-roles/helm_charts/files/helmcharts/insideoutmcp/values.yaml
@@ -23,6 +23,11 @@ service:
   type: ClusterIP
   port: 80
   targetPort: 8080
+  grpc:
+    enabled: false
+    port: 9090
+    targetPort: 9090
+  annotations: {}
 
 resources: {}
 imagePullSecrets: []


### PR DESCRIPTION
Closes luthersystems/mars#131.

Companion infra hook for [`luthersystems/reliable#1338` / PR #1343](https://github.com/luthersystems/reliable/pull/1343) (A2A SDK migration). The MCP server now wires an SDK gRPC handler via `a2agrpc/v1.NewHandler(rh).RegisterWith(s)`, gated on `MCP_GRPC_ADDR` (e.g. `:9090`). External reachability requires three pieces of infra; this is the chart side. Consumer-side wiring tracked in `luthersystems/ui-infrastructure#241`; CloudFront support tracked in `luthersystems/tf-modules#63`.

## Summary

- `templates/service.yaml` — conditional named `grpc` port (`appProtocol: grpc`) gated on `service.grpc.enabled`. Adds `.Values.service.annotations` passthrough on the Service `metadata` so the AWS Load Balancer Controller can scope `alb.ingress.kubernetes.io/backend-protocol-version: GRPC` per-Service (Ingress-wide would force HTTP/2 on every backend in the umbrella).
- `templates/deployment.yaml` — matching conditional `containerPort: 9090` named `grpc`.
- `values.yaml` — defaults: `service.grpc.enabled: false`, `service.grpc.port: 9090`, `service.grpc.targetPort: 9090`, `service.annotations: {}`. Existing deploys render byte-identical.
- `.gitignore` — add `.tmp/` (per global Claude Code convention).

## Test plan

```bash
CHART=ansible-roles/helm_charts/files/helmcharts/insideoutmcp

# 1. Defaults: byte-identical to main
helm template test "$CHART" > /tmp/after.yaml
git checkout main -- "$CHART"
helm template test "$CHART" > /tmp/before.yaml
git checkout - -- "$CHART"
diff /tmp/before.yaml /tmp/after.yaml   # → empty (verified)

# 2. grpc-enabled override: clean additive diff
cat > /tmp/grpc-on.yaml <<'YAML'
service:
  grpc:
    enabled: true
  annotations:
    alb.ingress.kubernetes.io/backend-protocol-version: GRPC
YAML
helm template test "$CHART" -f /tmp/grpc-on.yaml > /tmp/after-grpc.yaml
diff /tmp/after.yaml /tmp/after-grpc.yaml
```

Verified locally before push:
- Defaults: **byte-identical** to current main rendering.
- grpc-enabled: additive only — Service `metadata.annotations` gains the GRPC annotation; Service `spec.ports` gains `port: 9090, name: grpc, appProtocol: grpc`; Deployment container gains `containerPort: 9090, name: grpc`. No removed or modified fields.

## Review notes

- `/review` findings: P0: 0, P1: 0. P2 (advisory, not blocking): pre-existing `service.targetPort` dead config in values.yaml (not introduced by this change; left for follow-up); style nit on `{{- if }}` indent matching `connectorhub` pattern (current code matches `connectorhub`, intentional). P3 nits: hardcoded port name `grpc` (acceptable — name not referenced by anything else); `nindent 4` on annotations (verified correct against `metadata` indent).
- qa-professor: no test files changed (helm chart YAML only; no helm unit-test fixtures exist for this chart in the repo).
- Security pass: gRPC opt-in confirmed (`grpc.enabled: false` default); annotation injection is safe via `toYaml | nindent` on map input; no creds or endpoints introduced.

## Out of scope

- Pre-existing `service.targetPort: 8080` in values.yaml is dead config (the deployment hardcodes the container port). Untouched to keep PR scope tight.
- gRPC support for charts other than `insideoutmcp` — add when needed.