### PR TITLE
insideoutmcp chart: split gRPC into its own Service

### DIFF
--- a/ansible-roles/helm_charts/files/helmcharts/insideoutmcp/Chart.yaml
+++ b/ansible-roles/helm_charts/files/helmcharts/insideoutmcp/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: insideoutmcp
 description: "InsideOut MCP Server (SSE mode)"
-version: 0.1.0
+version: 0.2.0
 appVersion: "latest"
 

--- a/ansible-roles/helm_charts/files/helmcharts/insideoutmcp/templates/service-grpc.yaml
+++ b/ansible-roles/helm_charts/files/helmcharts/insideoutmcp/templates/service-grpc.yaml
@@ -1,20 +1,22 @@
+{{- if .Values.service.grpc.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "insideoutmcp.fullname" . }}
+  name: {{ include "insideoutmcp.fullname" . }}-grpc
   labels:
     {{- include "insideoutmcp.labels" . | nindent 4 }}
-  {{- with .Values.service.annotations }}
+  {{- with .Values.service.grpc.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
+    - port: {{ .Values.service.grpc.port }}
+      targetPort: {{ .Values.service.grpc.targetPort }}
       protocol: TCP
-      name: http
+      name: grpc
+      appProtocol: grpc
   selector:
     {{- include "insideoutmcp.labels.match" . | nindent 4 }}
-
+{{- end }}

--- a/ansible-roles/helm_charts/files/helmcharts/insideoutmcp/values.yaml
+++ b/ansible-roles/helm_charts/files/helmcharts/insideoutmcp/values.yaml
@@ -23,11 +23,12 @@ service:
   type: ClusterIP
   port: 80
   targetPort: 8080
+  annotations: {}
   grpc:
     enabled: false
     port: 9090
     targetPort: 9090
-  annotations: {}
+    annotations: {}
 
 resources: {}
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

Fixes the chart shape shipped in #132 / `v0.97.0`. Splits the gRPC port off the
multi-port `insideoutmcp` Service into a sibling Service named
`{{ include "insideoutmcp.fullname" . }}-grpc`, so AWS LBC's
`alb.ingress.kubernetes.io/backend-protocol-version: GRPC` annotation can
scope to only the gRPC target group.

The bug in #132 is that `backend-protocol-version` has no per-port scoping
syntax in AWS LBC. When set on a multi-port Service it applies to **every**
target group derived from that Service — so it would have flipped the
existing HTTP TG (port 80 → 8080) to GRPC, breaking all existing HTTP routes
to insideoutmcp (`/v1/insideout-mcp`, `/insideout-a2a/*`,
`/.well-known/agent.json`, `/.well-known/agent-card.json`). Pod-level
liveness/readiness probes still pass because they're kubelet → 8080 and
independent of ALB state, but every external HTTP request would have failed.

Discovered while planning [ui-infrastructure#241](https://github.com/luthersystems/ui-infrastructure/issues/241).

## Changes

- `values.yaml` — add `service.grpc.annotations: {}` (gRPC-Service-only); leave `service.annotations` as HTTP-Service-only.
- `templates/service.yaml` — remove the `service.grpc.enabled`-gated port (single-port HTTP).
- `templates/service-grpc.yaml` (new) — conditional sibling Service for the gRPC port; reuses `insideoutmcp.labels.match` selector to target the same pods.
- `Chart.yaml` — bump `version: 0.1.0 → 0.2.0` (additive resource; breaking values shape if anyone routed annotations through `service.annotations` expecting multi-port semantics — verified no such consumer exists).

No `Deployment` change — the existing `service.grpc.enabled`-gated `containerPort: 9090` block is correct as-is.

## Verification

```bash
cd ansible-roles/helm_charts/files/helmcharts

# Default (gRPC disabled): one Service umbrella-insideoutmcp, port 80.
helm template umbrella ./insideoutmcp

# gRPC enabled, distinct annotations:
helm template umbrella ./insideoutmcp \
    --set service.grpc.enabled=true \
    --set 'service.annotations.alb\.ingress\.kubernetes\.io/load-balancer-attributes=idle_timeout.timeout_seconds=60' \
    --set 'service.grpc.annotations.alb\.ingress\.kubernetes\.io/backend-protocol-version=GRPC'
# Two Services:
#  - umbrella-insideoutmcp (port 80, HTTP, idle_timeout annotation)
#  - umbrella-insideoutmcp-grpc (port 9090, appProtocol: grpc, backend-protocol-version: GRPC annotation)
```

Backwards-compat: helm template diff between `main` and this branch at default values is **only the chart version label** (`0.1.0 → 0.2.0`). No spec changes for consumers that haven't enabled gRPC.

## Test plan

- [x] `helm template` at default values: single HTTP Service, no gRPC, matches main except chart version label.
- [x] `helm template` with `service.grpc.enabled=true` + distinct annotations: emits two Services with correct annotation scoping.
- [ ] After release, ui-infrastructure#241 consumes the new chart shape and validates end-to-end on test cluster (curl /.well-known/agent-card.json shows three transports including GRPC; grpcurl reaches `a2a.v1.A2AService/GetExtendedAgentCard`).

Closes #133. Refs #131, #132, [luthersystems/ui-infrastructure#241](https://github.com/luthersystems/ui-infrastructure/issues/241).