### PR TITLE
umbrella role: accept any subchart version with wildcard '*'

### DIFF
--- a/ansible-roles/umbrella/templates/Chart.yaml.j2
+++ b/ansible-roles/umbrella/templates/Chart.yaml.j2
@@ -8,5 +8,5 @@ dependencies:
 {% for chart in umbrella_charts %}
   - name: {{ chart }}
     repository: file://{{ helm_charts_root_path }}/{{ chart }}
-    version: 0.1.0
+    version: '*'
 {% endfor %}


### PR DESCRIPTION
## Summary

Fixes a latent bug in the umbrella role's `Chart.yaml.j2` template that hardcoded `version: 0.1.0` for every subchart dependency. This breaks the moment any subchart's `Chart.yaml` is bumped above `0.1.0` (helm defaults subchart constraints to exact match).

mars v0.98.0 bumped `insideoutmcp` to `0.2.0` in #134 (chart split for gRPC `backend-protocol-version` scoping). The very next umbrella deploy in ui-infrastructure failed with:

```
Error: can't get a valid version for 1 subchart(s): "insideoutmcp"
(repository localhost ...)
```

## Fix

Change the umbrella subchart dep version from the hardcoded `0.1.0` to wildcard `'*'`. Helm wildcard satisfies any version; since the mars chart bundle is the single source of truth (`file://` repository, all charts shipped together), each chart can independently version-bump without touching the umbrella template.

## Test plan

- [ ] Manual `helm template` against the local chart bundle with `umbrella` rendered using mixed subchart versions (some at `0.1.0`, one at `0.2.0`) succeeds.
- [ ] After release, `gh workflow run deploy.yml -f environment=test -f playbook=app.yaml` in `luthersystems/ui-infrastructure` completes successfully (umbrella with `insideoutmcp` at `0.2.0`).

Closes #135. Refs #134, [luthersystems/ui-infrastructure#241](https://github.com/luthersystems/ui-infrastructure/issues/241).