### PR TITLE
chore: SHA-pin Actions and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/mars-ci.yml
+++ b/.github/workflows/mars-ci.yml
@@ -16,7 +16,7 @@ jobs:
         image:
           - mars
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           fetch-depth: 0 # include tags for VERSION detection
       - name: Build container

--- a/.github/workflows/mars-release.yml
+++ b/.github/workflows/mars-release.yml
@@ -18,7 +18,7 @@ jobs:
         image:
           - mars
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           fetch-depth: 0 # include tags for VERSION detection
       - name: Build container
@@ -33,10 +33,10 @@ jobs:
       - build-push
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Configure DockerHub
         uses: ./.github/actions/configure-dockerhub
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
       - name: Create and push manifest for multiarch
         run: make push-manifests GIT_TAG=$GITHUB_REF_NAME


### PR DESCRIPTION
## Summary

Part of the org hardening initiative (luthersystems/infosec#1).

### 1. Pin every external Action to a commit SHA

Replaces `uses: foo/bar@v4` with `uses: foo/bar@<sha>  # v4`. Defends against the tj-actions/changed-files class of attack, where a compromised maintainer can retroactively repoint a version tag to a malicious commit. SHA pins are immutable; tag pins are not.

Pinned in this PR:
- `actions/checkout@v5` → `93cb6ef` (# `v5`)
- `docker/setup-buildx-action@v4` → `4d04d5d` (# `v4`)

### 2. Add `.github/dependabot.yml`

Enables the `github-actions` ecosystem updater with grouped weekly updates. Dependabot auto-bumps SHAs (and updates the trailing version comments) every Monday, so pins stay current without manual maintenance.

Phase 1 only — the `github-actions` ecosystem. Runtime ecosystem (npm/pip/gomod) will be added per repo in Phase 2, once CI is confirmed green.

## Test plan

- [ ] CI passes (Actions resolve correctly with the SHA pins).
- [ ] After merge, confirm Dependabot picks up the new config.
