### PR TITLE
Fix root Mars help and version commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,13 +78,14 @@ RUN /opt/mars_venv/bin/pip install -r /tmp/requirements.txt
 
 FROM golang:1.25-bookworm AS mars-cli
 ARG TARGETARCH
+ARG MARS_VERSION=dev
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY cmd ./cmd
 COPY internal ./internal
 RUN mkdir -p /out && \
-  CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o /out/mars ./cmd/mars && \
+  CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w -X github.com/luthersystems/mars/internal/cli.Version=${MARS_VERSION}" -o /out/mars ./cmd/mars && \
   CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o /out/mars-entrypoint ./cmd/mars-entrypoint && \
   CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o /out/insideout-reverse-import ./cmd/insideout-reverse-import && \
   CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o /out/vault-aws-secretsmanager ./cmd/vault-aws-secretsmanager && \

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ build-%: Dockerfile go.mod go.sum ${GO_SOURCES} ${ANSIBLE_ROLES} ${ANSIBLE_PLUGI
 		--build-arg TFENV_VER=${TFENV_VER} \
 		--build-arg HELM_VERSION=${HELM_VERSION} \
 		--build-arg HELM_DIFF_VERSION=${HELM_DIFF_VERSION} \
+		--build-arg MARS_VERSION=${VERSION} \
 		${LOADARG} \
 		-t ${STATIC_IMAGE}:${VERSION} \
 		.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -43,16 +43,9 @@ type CLI struct {
 	ALBDNS alb.DNSCmd `cmd:"" name:"alb-dns" help:"Print matching ALB DNS names."`
 }
 
+var Version = "dev"
+
 func Main(ctx context.Context, args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, r runner.Runner) int {
-	if len(args) == 0 {
-		fmt.Fprintln(stderr, "no arguments provided")
-		return 1
-	}
-	if len(args) < 2 {
-		fmt.Fprintln(stderr, "missing command")
-		return 1
-	}
-	target, cleanArgs, verbosity, skipPrompt := extractTerraformGlobals(args)
 	var root CLI
 	parser, err := kong.New(
 		&root,
@@ -65,6 +58,26 @@ func Main(ctx context.Context, args []string, stdin io.Reader, stdout io.Writer,
 		fmt.Fprintln(stderr, err)
 		return 1
 	}
+	if isRootHelp(args) {
+		if err := printRootUsage(parser); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	}
+	if isRootVersion(args) {
+		fmt.Fprintln(stdout, Version)
+		return 0
+	}
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "no arguments provided")
+		return 1
+	}
+	if len(args) < 2 {
+		fmt.Fprintln(stderr, "missing command")
+		return 1
+	}
+	target, cleanArgs, verbosity, skipPrompt := extractTerraformGlobals(args)
 	parsed, err := parser.Parse(cleanArgs)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
@@ -84,6 +97,22 @@ func Main(ctx context.Context, args []string, stdin io.Reader, stdout io.Writer,
 		return runner.ExitCode(err)
 	}
 	return 0
+}
+
+func isRootHelp(args []string) bool {
+	return len(args) == 1 && (args[0] == "--help" || args[0] == "-h" || args[0] == "help")
+}
+
+func isRootVersion(args []string) bool {
+	return len(args) == 1 && (args[0] == "--version" || args[0] == "version")
+}
+
+func printRootUsage(parser *kong.Kong) error {
+	ctx, err := kong.Trace(parser, nil)
+	if err != nil {
+		return err
+	}
+	return ctx.PrintUsage(false)
 }
 
 func extractTerraformGlobals(args []string) (string, []string, int, bool) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -65,6 +65,75 @@ func TestTerraformRawCommandPassesFlagsAfterDoubleDash(t *testing.T) {
 	})
 }
 
+func TestRootHelpDoesNotRequireTarget(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "long", args: []string{"--help"}},
+		{name: "short", args: []string{"-h"}},
+		{name: "command", args: []string{"help"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &runner.Fake{}
+			var stdout, stderr bytes.Buffer
+
+			code := Main(context.Background(), tt.args, strings.NewReader(""), &stdout, &stderr, fake)
+
+			if code != 0 {
+				t.Fatalf("exit code = %d, stderr:\n%s", code, stderr.String())
+			}
+			if !strings.Contains(stdout.String(), "Luther Systems infrastructure management tool.") {
+				t.Fatalf("stdout did not include root help, got:\n%s", stdout.String())
+			}
+			if strings.Contains(stderr.String(), "missing command") {
+				t.Fatalf("stderr contains missing command: %q", stderr.String())
+			}
+			if len(fake.Records) != 0 {
+				t.Fatalf("root help should not run external commands, got %s", fake.Output())
+			}
+		})
+	}
+}
+
+func TestRootVersionDoesNotRequireTarget(t *testing.T) {
+	oldVersion := Version
+	Version = "test-version"
+	t.Cleanup(func() {
+		Version = oldVersion
+	})
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "flag", args: []string{"--version"}},
+		{name: "command", args: []string{"version"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &runner.Fake{}
+			var stdout, stderr bytes.Buffer
+
+			code := Main(context.Background(), tt.args, strings.NewReader(""), &stdout, &stderr, fake)
+
+			if code != 0 {
+				t.Fatalf("exit code = %d, stderr:\n%s", code, stderr.String())
+			}
+			if got := stdout.String(); got != "test-version\n" {
+				t.Fatalf("stdout = %q, want test-version newline", got)
+			}
+			if strings.Contains(stderr.String(), "missing command") {
+				t.Fatalf("stderr contains missing command: %q", stderr.String())
+			}
+			if len(fake.Records) != 0 {
+				t.Fatalf("root version should not run external commands, got %s", fake.Output())
+			}
+		})
+	}
+}
+
 func TestAnsiblePlaybookUsesInventoryAndVaultDefaults(t *testing.T) {
 	withProject(t, func(dir string) {
 		writeFile(t, "vault_password.txt", "password")


### PR DESCRIPTION
## Summary

- Allows root `mars --help`, `mars -h`, and `mars help` before requiring a target environment.
- Adds root `mars --version` and `mars version`.
- Injects the release tag into the Mars binary during Docker builds.

Closes #151

## Test plan

- [x] `go test ./internal/cli`
- [x] `go test ./internal/reverseimportjob`
- [x] `go test ./...`
- [x] `go build -trimpath -ldflags "-s -w -X github.com/luthersystems/mars/internal/cli.Version=test-build" -o .tmp/mars ./cmd/mars`
- [x] `.tmp/mars --help`
- [x] `.tmp/mars -h`
- [x] `.tmp/mars help`
- [x] `.tmp/mars --version && .tmp/mars version`
- [x] `git diff --check`

## Security review

- No new network, filesystem, auth, or credential handling.
- Version output is build metadata only.
- Help/version paths return before command execution and do not invoke Terraform, Ansible, or shell commands.

## QA review

- Added regression tests cover all root help/version spellings and assert no external commands run.
