### PR TITLE
Fix Helm 4 Ansible compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,29 +123,23 @@ WORKDIR /marsproject
 COPY ansible-reqs.yml /opt/mars/ansible-reqs.yml
 RUN ansible-galaxy install -r /opt/mars/ansible-reqs.yml
 
-# Patch kubernetes.core for Helm v4 compatibility (kubernetes.core 5.4.2 lacks support).
-# These patches match fixes in upstream PR #1090 (merged to main, not yet released).
-# Remove when upgrading to a kubernetes.core release with Helm v4 support.
-RUN find / -type d -path "*/ansible_collections/kubernetes/core" 2>/dev/null | while read K8S_CORE; do \
-      # 1. Remove --all from "helm list" (removed in Helm 4, now default behavior) \
-      sed -i 's/list_command.append("--all")/pass  # --all removed in Helm v4/' "$K8S_CORE/plugins/modules/helm.py" && \
-      # 2. Remove version check that rejects Helm >=4.0.0 \
-      sed -i 's/LooseVersion(helm_version) >= LooseVersion("4.0.0")/False/' "$K8S_CORE/plugins/module_utils/helm.py"; \
-    done
-
 COPY --from=downloader /tmp/tfedit /opt/bin/tfedit
 COPY --from=downloader /tmp/tfmigrate /opt/bin/tfmigrate
+COPY --from=mars-cli /out/mars /opt/bin/mars
+COPY --from=mars-cli /out/mars-entrypoint /opt/bin/mars-entrypoint
 COPY --from=mars-cli /out/insideout-reverse-import /opt/bin/insideout-reverse-import
+COPY --from=mars-cli /out/vault-aws-secretsmanager /opt/bin/vault-aws-secretsmanager
+COPY --from=mars-cli /out/vault-az-keyvault /opt/bin/vault-az-keyvault
 COPY --from=downloader /tmp/awscliv2.zip /tmp/awscliv2.zip
 RUN unzip -d /tmp /tmp/awscliv2.zip && /tmp/aws/install && rm -rf /tmp/aws*
 
 ENTRYPOINT ["/opt/mars/mars-entrypoint"]
 
-COPY --from=mars-cli /out/mars /opt/mars/mars
-COPY --from=mars-cli /out/mars-entrypoint /opt/mars/mars-entrypoint
-COPY --from=mars-cli /out/vault-aws-secretsmanager /opt/mars/vault-aws-secretsmanager
-COPY --from=mars-cli /out/vault-az-keyvault /opt/mars/vault-az-keyvault
-RUN chmod a+x /opt/mars/mars /opt/mars/mars-entrypoint /opt/mars/vault-aws-secretsmanager /opt/mars/vault-az-keyvault
+RUN chmod a+x /opt/bin/mars /opt/bin/mars-entrypoint /opt/bin/vault-aws-secretsmanager /opt/bin/vault-az-keyvault && \
+  ln -sf /opt/bin/mars /opt/mars/mars && \
+  ln -sf /opt/bin/mars-entrypoint /opt/mars/mars-entrypoint && \
+  ln -sf /opt/bin/vault-aws-secretsmanager /opt/mars/vault-aws-secretsmanager && \
+  ln -sf /opt/bin/vault-az-keyvault /opt/mars/vault-az-keyvault
 RUN chmod a+x /opt/bin/insideout-reverse-import && ln -sf /opt/bin/insideout-reverse-import /usr/local/bin/insideout-reverse-import
 
 COPY ssh_config /etc/ssh/ssh_config

--- a/ansible-reqs.yml
+++ b/ansible-reqs.yml
@@ -1,6 +1,6 @@
 ---
 collections:
 - name: kubernetes.core
-  version: 5.4.2
+  version: 6.4.0
 - name: prometheus.prometheus
   version: 0.16.3

--- a/mars_macos.sh
+++ b/mars_macos.sh
@@ -69,11 +69,13 @@ PROJECT_PATH=$(fullpath ${PROJECT_PATH:-$(pwd)})
 WORK_REL_PATH="${PWD#$PROJECT_PATH}" # Includes leading dir separator
 DOCKER_WORK_DIR="$DOCKER_PROJECT_PATH$WORK_REL_PATH"
 
-MARS_VERSION=latest
-if [ -f "$PROJECT_PATH/.mars-version" ]; then
-	MARS_VERSION=$(cat $PROJECT_PATH/.mars-version)
-elif [ -f "$GIT_ROOT/.mars-version" ]; then
-	MARS_VERSION=$(cat $GIT_ROOT/.mars-version)
+if [ -z "${MARS_VERSION:-}" ]; then
+	MARS_VERSION=latest
+	if [ -f "$PROJECT_PATH/.mars-version" ]; then
+		MARS_VERSION=$(cat $PROJECT_PATH/.mars-version)
+	elif [ -f "$GIT_ROOT/.mars-version" ]; then
+		MARS_VERSION=$(cat $GIT_ROOT/.mars-version)
+	fi
 fi
 
 ENV_VARS=
@@ -130,7 +132,7 @@ docker run --rm $DOCKER_TERM_VARS \
 	-e USER_ID=$(id -u $USER) \
 	-e GROUP_ID=$(id -g $USER) \
 	-e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
-	-e AWS_SECURITY_TOKEN -e AWS_SESSION_TOKEN \
+	-e AWS_SESSION_TOKEN \
 	-e TF_PLUGIN_CACHE_DIR=/opt/tf-plugin-cache-dir \
 	-e GITHUB_TOKEN \
 	$ENV_VARS \

--- a/scripts/mars
+++ b/scripts/mars
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /opt/bin/mars "$@"

--- a/scripts/mars-entrypoint
+++ b/scripts/mars-entrypoint
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /opt/bin/mars-entrypoint "$@"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /opt/bin/mars-entrypoint "$@"

--- a/scripts/vault-aws-secretsmanager
+++ b/scripts/vault-aws-secretsmanager
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /opt/bin/vault-aws-secretsmanager "$@"

--- a/scripts/vault-az-keyvault
+++ b/scripts/vault-az-keyvault
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /opt/bin/vault-az-keyvault "$@"


### PR DESCRIPTION
## Summary

- Bump `kubernetes.core` to `6.4.0`, which includes upstream Helm 4 compatibility, and remove the local sed patch hacks.
- Store Mars helper binaries in `/opt/bin` and symlink `/opt/mars/*` to them so old `MARS_DEV_ROOT/scripts:/opt/mars` wrapper flows can call stable binary paths.
- Add `scripts/` compatibility shims and tighten the macOS wrapper so `MARS_VERSION` overrides are respected and deprecated `AWS_SECURITY_TOKEN` is not forwarded.

Closes #155

## Test plan

- [x] Built local arm64 image: `make build-arm64 VERSION=helm4-k8s-core-640-test`
- [x] Container sanity: `kubernetes.core 6.4.0` is installed and `/opt/mars/*` points at `/opt/bin/*`
- [x] Compat smoke: old-style `scripts:/opt/mars` mount can run `mars-entrypoint --version`
- [x] Real ui-infrastructure smoke: `test ansible-playbook --aws-sm-secret-id=... --aws-region=... --aws-role-arn=... umbrella.yaml` passed, including `k8s_pvc : Install helm chart`
- [x] Wrapper smoke: `MARS_VERSION=helm4-k8s-core-640-test MARS_DEV=true ... ./mars_macos.sh --version`
- [x] `git diff --check`
- [x] `go test ./...`

## Security review

- No new credentials, endpoints, auth logic, or network listeners.
- Wrapper no longer forwards deprecated `AWS_SECURITY_TOKEN`, avoiding mismatched AWS session credentials when `AWS_SESSION_TOKEN` is present.
- New shell shims only `exec` fixed image paths and pass through arguments.
