### PR TITLE
fix: make init scripts idempotent

### DIFF
--- a/ansible-roles/helm_charts/files/helmcharts/connectorhub/templates/deployment.yaml
+++ b/ansible-roles/helm_charts/files/helmcharts/connectorhub/templates/deployment.yaml
@@ -134,7 +134,8 @@ spec:
               cd /tmp
               unzip crypto-config.zip
               # TODO: copy only relevant files
-              mv crypto-config /fabric/
+              mkdir -p /fabric/crypto-config
+              cp -a crypto-config/. /fabric/crypto-config/
           volumeMounts:
             - name: fabric-artifacts
               mountPath: /fabric

--- a/ansible-roles/helm_charts/files/helmcharts/shiroclient/templates/deployment.yaml
+++ b/ansible-roles/helm_charts/files/helmcharts/shiroclient/templates/deployment.yaml
@@ -211,7 +211,8 @@ spec:
               cd /tmp
               unzip crypto-config.zip
               # TODO: copy only relevant files
-              mv crypto-config /fabric/
+              mkdir -p /fabric/crypto-config
+              cp -a crypto-config/. /fabric/crypto-config/
           volumeMounts:
             - name: fabric-artifacts
               mountPath: /fabric

--- a/ansible-roles/k8s_fabric_ca/files/fabric-ca/templates/deployment.yaml
+++ b/ansible-roles/k8s_fabric_ca/files/fabric-ca/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
               unzip crypto-config.zip
               cd crypto-config
 
-              mv peerOrganizations/{{ .Values.dlt.domain }}/ca/* /crypto
+              cp -a peerOrganizations/{{ .Values.dlt.domain }}/ca/. /crypto/
           volumeMounts:
             - name: crypto
               mountPath: /crypto

--- a/ansible-roles/k8s_fabric_cli/files/fabric-cli/templates/deployment.yaml
+++ b/ansible-roles/k8s_fabric_cli/files/fabric-cli/templates/deployment.yaml
@@ -160,14 +160,14 @@ spec:
 
               cp /opt/channel-artifacts/channel-artifacts.zip /tmp
               unzip channel-artifacts.zip
-              mv channel-artifacts/* /channel-artifacts
+              cp -a channel-artifacts/. /channel-artifacts/
 
               cp /opt/collections/collections.json /collections-config/
 
               cp /opt/crypto-config/crypto-config.zip /tmp
               unzip crypto-config.zip
 
-              mv crypto-config/ordererOrganizations/{{ .Values.dlt.domain }}/orderers/orderer0.{{ .Values.dlt.domain }}/msp/tlscacerts/* /orderertls
+              cp -a crypto-config/ordererOrganizations/{{ .Values.dlt.domain }}/orderers/orderer0.{{ .Values.dlt.domain }}/msp/tlscacerts/. /orderertls/
               mkdir -p /tls/all-cas
               cd crypto-config/peerOrganizations
               cp --parents $(find . -name ca.crt) /tls/all-cas
@@ -175,11 +175,11 @@ spec:
 
               # TODO: replace domain var with proper orderer domain
               {{- if eq .Values.dlt.organization "orderer" }}
-              mv ordererOrganizations/{{ .Values.dlt.domain }}/users/Admin@{{ .Values.dlt.domain }}/msp/* /msp
-              mv ordererOrganizations/{{ .Values.dlt.domain }}/orderers/orderer{{ .Values.dlt.peerIndex }}.{{ .Values.dlt.domain }}/tls/* /tls
+              cp -a ordererOrganizations/{{ .Values.dlt.domain }}/users/Admin@{{ .Values.dlt.domain }}/msp/. /msp/
+              cp -a ordererOrganizations/{{ .Values.dlt.domain }}/orderers/orderer{{ .Values.dlt.peerIndex }}.{{ .Values.dlt.domain }}/tls/. /tls/
               {{- else }}
-              mv peerOrganizations/{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/users/Admin@{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/msp/* /msp
-              mv peerOrganizations/{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/peers/{{ list .Values.dlt.peerIndex . | include "fabric-cli.peer-fqdn" }}/tls/* /tls
+              cp -a peerOrganizations/{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/users/Admin@{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/msp/. /msp/
+              cp -a peerOrganizations/{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/peers/{{ list .Values.dlt.peerIndex . | include "fabric-cli.peer-fqdn" }}/tls/. /tls/
               {{- end }}
           volumeMounts:
             - name: orderertls

--- a/ansible-roles/k8s_fabric_orderer/files/fabric-orderer/templates/deployment.yaml
+++ b/ansible-roles/k8s_fabric_orderer/files/fabric-orderer/templates/deployment.yaml
@@ -159,14 +159,14 @@ spec:
 
               cp /opt/channel-artifacts/channel-artifacts.zip /tmp
               unzip channel-artifacts.zip
-              mv channel-artifacts/* /channel-artifacts
+              cp -a channel-artifacts/. /channel-artifacts/
 
               cp /opt/crypto-config/crypto-config.zip /tmp
               unzip crypto-config.zip
               cd crypto-config
 
-              mv ordererOrganizations/{{ .Values.dlt.domain }}/orderers/{{ include "fabric-orderer.self-fqdn" . }}/msp/* /msp
-              mv ordererOrganizations/{{ .Values.dlt.domain }}/orderers/{{ include "fabric-orderer.self-fqdn" . }}/tls/* /tls
+              cp -a ordererOrganizations/{{ .Values.dlt.domain }}/orderers/{{ include "fabric-orderer.self-fqdn" . }}/msp/. /msp/
+              cp -a ordererOrganizations/{{ .Values.dlt.domain }}/orderers/{{ include "fabric-orderer.self-fqdn" . }}/tls/. /tls/
           volumeMounts:
             - name: genesisblock
               mountPath: /channel-artifacts

--- a/ansible-roles/k8s_fabric_peer/files/fabric-peer/templates/deployment.yaml
+++ b/ansible-roles/k8s_fabric_peer/files/fabric-peer/templates/deployment.yaml
@@ -335,10 +335,10 @@ spec:
               unzip crypto-config.zip
               cd crypto-config
               # TODO: replace domain var with proper orderer domain
-              mv ordererOrganizations/{{ .Values.dlt.domain }}/orderers/orderer0.{{ .Values.dlt.domain }}/msp/tlscacerts/* /orderertls
-              mv peerOrganizations/{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/peers/{{ include "fabric-peer.self-fqdn" . }}/msp/* /msp
-              mv peerOrganizations/{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/peers/{{ include "fabric-peer.self-fqdn" . }}/tls/* /tls
-              mv peerOrganizations/{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/users/Admin@{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/msp/* /adminmsp
+              cp -a ordererOrganizations/{{ .Values.dlt.domain }}/orderers/orderer0.{{ .Values.dlt.domain }}/msp/tlscacerts/. /orderertls/
+              cp -a peerOrganizations/{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/peers/{{ include "fabric-peer.self-fqdn" . }}/msp/. /msp/
+              cp -a peerOrganizations/{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/peers/{{ include "fabric-peer.self-fqdn" . }}/tls/. /tls/
+              cp -a peerOrganizations/{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/users/Admin@{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/msp/. /adminmsp/
           volumeMounts:
             - name: orderertls
               mountPath: /orderertls

--- a/internal/charttemplates/init_scripts_test.go
+++ b/internal/charttemplates/init_scripts_test.go
@@ -1,0 +1,97 @@
+package charttemplates
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestInitScriptsCopyConfigIntoExistingDestinations(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		copies []string
+	}{
+		{
+			name:   "connectorhub crypto config",
+			path:   "ansible-roles/helm_charts/files/helmcharts/connectorhub/templates/deployment.yaml",
+			copies: []string{"cp -a crypto-config/. /fabric/crypto-config/"},
+		},
+		{
+			name:   "shiroclient crypto config",
+			path:   "ansible-roles/helm_charts/files/helmcharts/shiroclient/templates/deployment.yaml",
+			copies: []string{"cp -a crypto-config/. /fabric/crypto-config/"},
+		},
+		{
+			name: "fabric cli config",
+			path: "ansible-roles/k8s_fabric_cli/files/fabric-cli/templates/deployment.yaml",
+			copies: []string{
+				"cp -a channel-artifacts/. /channel-artifacts/",
+				"cp -a crypto-config/ordererOrganizations/{{ .Values.dlt.domain }}/orderers/orderer0.{{ .Values.dlt.domain }}/msp/tlscacerts/. /orderertls/",
+				"cp -a ordererOrganizations/{{ .Values.dlt.domain }}/users/Admin@{{ .Values.dlt.domain }}/msp/. /msp/",
+				"cp -a ordererOrganizations/{{ .Values.dlt.domain }}/orderers/orderer{{ .Values.dlt.peerIndex }}.{{ .Values.dlt.domain }}/tls/. /tls/",
+				"cp -a peerOrganizations/{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/users/Admin@{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/msp/. /msp/",
+				"cp -a peerOrganizations/{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/peers/{{ list .Values.dlt.peerIndex . | include \"fabric-cli.peer-fqdn\" }}/tls/. /tls/",
+			},
+		},
+		{
+			name: "fabric orderer config",
+			path: "ansible-roles/k8s_fabric_orderer/files/fabric-orderer/templates/deployment.yaml",
+			copies: []string{
+				"cp -a channel-artifacts/. /channel-artifacts/",
+				"cp -a ordererOrganizations/{{ .Values.dlt.domain }}/orderers/{{ include \"fabric-orderer.self-fqdn\" . }}/msp/. /msp/",
+				"cp -a ordererOrganizations/{{ .Values.dlt.domain }}/orderers/{{ include \"fabric-orderer.self-fqdn\" . }}/tls/. /tls/",
+			},
+		},
+		{
+			name: "fabric peer config",
+			path: "ansible-roles/k8s_fabric_peer/files/fabric-peer/templates/deployment.yaml",
+			copies: []string{
+				"cp -a ordererOrganizations/{{ .Values.dlt.domain }}/orderers/orderer0.{{ .Values.dlt.domain }}/msp/tlscacerts/. /orderertls/",
+				"cp -a peerOrganizations/{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/peers/{{ include \"fabric-peer.self-fqdn\" . }}/msp/. /msp/",
+				"cp -a peerOrganizations/{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/peers/{{ include \"fabric-peer.self-fqdn\" . }}/tls/. /tls/",
+				"cp -a peerOrganizations/{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/users/Admin@{{ .Values.dlt.organization }}.{{ .Values.dlt.domain }}/msp/. /adminmsp/",
+			},
+		},
+		{
+			name:   "fabric ca crypto config",
+			path:   "ansible-roles/k8s_fabric_ca/files/fabric-ca/templates/deployment.yaml",
+			copies: []string{"cp -a peerOrganizations/{{ .Values.dlt.domain }}/ca/. /crypto/"},
+		},
+	}
+
+	root := repoRoot(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content, err := os.ReadFile(filepath.Join(root, tt.path))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			text := string(content)
+			for _, copyCmd := range tt.copies {
+				if !strings.Contains(text, copyCmd) {
+					t.Fatalf("missing copy command %q", copyCmd)
+				}
+			}
+			if strings.Contains(text, "rm -rf") {
+				t.Fatal("init script should not delete destination mount contents")
+			}
+			if strings.Contains(text, "mv ") {
+				t.Fatal("init script should copy into existing destination mounts instead of moving")
+			}
+		})
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve caller")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", ".."))
+}


### PR DESCRIPTION
## Summary
- Make connectorhub and shiroclient crypto-config init scripts copy into existing mount dirs instead of moving into them.
- Make Fabric CA/CLI/orderer/peer init scripts copy config artifacts into mount dirs so init retries survive existing directories.
- Add a regression test covering the affected chart templates and blocking `mv`/`rm -rf` reintroduction in those init scripts.

## Test plan
- [x] `go test ./...`
- [x] `git diff --check`
- [x] Live stage recovery evidence: after recreating stale Fabric and connectorhub pods, downstream ui-infrastructure deploy [26338725099](https://github.com/luthersystems/ui-infrastructure/actions/runs/26338725099) completed successfully.

## QA review
- PASS: the added test is narrow but tied to the observed failure mode. It checks exact copy-over commands for every affected template and rejects destructive or non-idempotent `rm -rf` / `mv` reintroduction.
- Residual gap: this does not render every Helm chart; CI should run the normal Mars test/build gates.

## Security review
- Low risk. The change removes destructive init cleanup and does not touch auth, secrets, or runtime credentials.

Closes #163
