### PR TITLE
fix: bake aws+gcp terraform providers into image (#165)

### DIFF
--- a/.github/workflows/mars-ci.yml
+++ b/.github/workflows/mars-ci.yml
@@ -28,7 +28,4 @@ jobs:
       - name: Verify terraform provider cache
         if: matrix.image == 'mars'
         shell: bash
-        run: |
-          IMAGE=$(docker images luthersystems/mars --format '{{.Repository}}:{{.Tag}}' | head -1)
-          [ -n "$IMAGE" ] || { echo "no mars image found locally"; exit 1; }
-          ./scripts/smoke-tf-cache.sh "$IMAGE"
+        run: ./scripts/smoke-tf-cache.sh "luthersystems/mars:${GITHUB_SHA}"

--- a/.github/workflows/mars-ci.yml
+++ b/.github/workflows/mars-ci.yml
@@ -25,3 +25,10 @@ jobs:
           arch: ${{ matrix.arch }}
           image: .
           git_rev: $GITHUB_SHA
+      - name: Verify terraform provider cache
+        if: matrix.image == 'mars'
+        shell: bash
+        run: |
+          IMAGE=$(docker images luthersystems/mars --format '{{.Repository}}:{{.Tag}}' | head -1)
+          [ -n "$IMAGE" ] || { echo "no mars image found locally"; exit 1; }
+          ./scripts/smoke-tf-cache.sh "$IMAGE"

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,9 +90,12 @@ RUN apt update -y && apt install --no-install-recommends -yq \
 # Throwaway terraform used only to populate the plugin cache. Not copied into
 # the final image; consumers still pick their TF version via tfenv.
 ARG TF_WARMUP_VERSION=1.9.8
-RUN curl -fsSL -o /tmp/tf.zip "https://releases.hashicorp.com/terraform/${TF_WARMUP_VERSION}/terraform_${TF_WARMUP_VERSION}_linux_${TARGETARCH}.zip" \
-  && unzip -d /usr/local/bin /tmp/tf.zip \
-  && rm /tmp/tf.zip
+RUN cd /tmp \
+  && curl -fsSL -o "terraform_${TF_WARMUP_VERSION}_linux_${TARGETARCH}.zip" "https://releases.hashicorp.com/terraform/${TF_WARMUP_VERSION}/terraform_${TF_WARMUP_VERSION}_linux_${TARGETARCH}.zip" \
+  && curl -fsSL -o tf_SHA256SUMS "https://releases.hashicorp.com/terraform/${TF_WARMUP_VERSION}/terraform_${TF_WARMUP_VERSION}_SHA256SUMS" \
+  && grep "  terraform_${TF_WARMUP_VERSION}_linux_${TARGETARCH}.zip$" tf_SHA256SUMS | sha256sum -c --strict - \
+  && unzip -d /usr/local/bin "terraform_${TF_WARMUP_VERSION}_linux_${TARGETARCH}.zip" \
+  && rm "terraform_${TF_WARMUP_VERSION}_linux_${TARGETARCH}.zip" tf_SHA256SUMS
 
 # Provider versions are kept in sync with insideout-terraform-presets.
 # Bump these together with the presets repo to keep cache hits useful.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 FROM ubuntu:24.04 AS downloader
 ARG TARGETARCH
 ENV TARGETARCH=$TARGETARCH
@@ -75,6 +77,42 @@ RUN mkdir -p /opt/mars
 RUN python3 -m venv /opt/mars_venv
 RUN /opt/mars_venv/bin/pip install setuptools
 RUN /opt/mars_venv/bin/pip install -r /tmp/requirements.txt
+
+FROM ubuntu:24.04 AS tf-providers
+ARG TARGETARCH
+ENV TF_PLUGIN_CACHE_DIR=/opt/tf-plugin-cache
+
+RUN apt update -y && apt install --no-install-recommends -yq \
+  ca-certificates \
+  curl \
+  unzip
+
+# Throwaway terraform used only to populate the plugin cache. Not copied into
+# the final image; consumers still pick their TF version via tfenv.
+ARG TF_WARMUP_VERSION=1.9.8
+RUN curl -fsSL -o /tmp/tf.zip "https://releases.hashicorp.com/terraform/${TF_WARMUP_VERSION}/terraform_${TF_WARMUP_VERSION}_linux_${TARGETARCH}.zip" \
+  && unzip -d /usr/local/bin /tmp/tf.zip \
+  && rm /tmp/tf.zip
+
+# Provider versions are kept in sync with insideout-terraform-presets.
+# Bump these together with the presets repo to keep cache hits useful.
+ARG AWS_PROVIDER_VERSION=6.45.0
+ARG GOOGLE_PROVIDER_VERSION=6.10.0
+
+RUN mkdir -p ${TF_PLUGIN_CACHE_DIR} /tmp/warmup
+WORKDIR /tmp/warmup
+RUN printf '%s\n' \
+  'terraform {' \
+  '  required_providers {' \
+  "    aws         = { source = \"hashicorp/aws\",         version = \"= ${AWS_PROVIDER_VERSION}\" }" \
+  "    google      = { source = \"hashicorp/google\",      version = \"= ${GOOGLE_PROVIDER_VERSION}\" }" \
+  "    google-beta = { source = \"hashicorp/google-beta\", version = \"= ${GOOGLE_PROVIDER_VERSION}\" }" \
+  '  }' \
+  '}' \
+  > main.tf
+RUN terraform init -input=false -backend=false
+# Ensure runtime users can read the cache even when Docker copies as root.
+RUN chmod -R a+rX ${TF_PLUGIN_CACHE_DIR}
 
 FROM golang:1.25-bookworm AS mars-cli
 ARG TARGETARCH
@@ -158,6 +196,13 @@ COPY grafana-dashboards /opt/grafana-dashboards
 COPY --from=downloader /tmp/tfenv /opt/tfenv
 RUN mkdir -p /opt/tfenv/versions && chmod -R a+w /opt/tfenv/versions && echo 'trust-tfenv: yes' > /opt/tfenv/use-gpgv
 ENV PATH="/opt/tfenv/bin:/opt/bin:${PATH}"
+
+# Pre-warmed terraform provider cache for the providers pinned by
+# insideout-terraform-presets. Consumers get cache hits as long as their
+# .terraform.lock.hcl carries linux_amd64 / linux_arm64 h1 hashes; otherwise
+# terraform falls back to downloading from the registry as before.
+COPY --from=tf-providers /opt/tf-plugin-cache /opt/tf-plugin-cache
+ENV TF_PLUGIN_CACHE_DIR=/opt/tf-plugin-cache
 
 COPY --from=downloader /usr/local/bin/helm /opt/bin/helm
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,38 @@ parsing them as Mars flags.
 mars dev terraform -- providers --help
 ```
 
+### Pre-warmed provider plugin cache
+
+The image sets `TF_PLUGIN_CACHE_DIR=/opt/tf-plugin-cache` and ships pre-warmed
+binaries for the providers pinned by `insideout-terraform-presets`:
+
+- `hashicorp/aws`
+- `hashicorp/google`
+- `hashicorp/google-beta`
+
+`terraform init` will symlink these into `.terraform/providers/` instead of
+downloading them, which both speeds up `init` and keeps Argo workflow artifact
+tarballs small (symlinks archive as a few bytes instead of ~1 GB of provider
+binary).
+
+**Lockfile requirement.** Terraform validates cache hits against the `h1:`
+hashes in `.terraform.lock.hcl`. By default a lockfile only carries the hash
+for the platform `terraform init` was run on, so a Mac-generated lockfile will
+miss the Linux cache. To get cache hits in both the amd64 and arm64 mars
+images, regenerate consumer lockfiles with both Linux platforms:
+
+```
+mars <env> terraform -- providers lock \
+  -platform=linux_amd64 -platform=linux_arm64
+```
+
+If the lockfile is missing the right hash, terraform falls back to downloading
+the provider from the registry — same behavior as before this cache existed.
+
+Provider versions are pinned at build time via `AWS_PROVIDER_VERSION` and
+`GOOGLE_PROVIDER_VERSION` ARGs in the Dockerfile. Bump them in lockstep with
+`insideout-terraform-presets`.
+
 # Setting up managed repositories
 
 Place a .mars-version file at the root of the mars managed infrastructure

--- a/scripts/smoke-tf-cache.sh
+++ b/scripts/smoke-tf-cache.sh
@@ -1,32 +1,73 @@
 #!/usr/bin/env bash
 # Verify that the mars image ships a populated terraform provider plugin
-# cache for the current arch. Fails if any expected provider binary is
-# missing or non-executable.
+# cache for the current arch with the exact provider versions we expect.
+# Fails on:
+#   - missing or non-executable provider binary at the expected path
+#   - filename mismatch (wrong version or wrong provider)
+#   - more than one binary in the per-arch directory (cache shape unexpected)
+#   - implausibly small binary (build copied a stub)
+#   - TF_PLUGIN_CACHE_DIR unset or pointing somewhere unexpected
 set -euo pipefail
 
 IMAGE="${1:?usage: smoke-tf-cache.sh <image>}"
 
 docker run --rm --entrypoint /bin/bash "${IMAGE}" -c '
 set -euo pipefail
+shopt -s nullglob
+
 arch=$(uname -m | sed -e s/x86_64/amd64/ -e s/aarch64/arm64/)
+
+# (provider-source, version, expected filename in the per-arch dir)
 expect=(
-  registry.terraform.io/hashicorp/aws/6.45.0
-  registry.terraform.io/hashicorp/google/6.10.0
-  registry.terraform.io/hashicorp/google-beta/6.10.0
+  "hashicorp/aws         6.45.0 terraform-provider-aws_v6.45.0_x5"
+  "hashicorp/google      6.10.0 terraform-provider-google_v6.10.0_x5"
+  "hashicorp/google-beta 6.10.0 terraform-provider-google-beta_v6.10.0_x5"
 )
+
+# Sanity floor on the provider binary size. AWS is ~750 MB, google ~100 MB.
+# Set the floor low enough to allow some slack from upstream rebuilds but
+# high enough to catch a stub or empty-file regression.
+min_bytes=50000000  # 50 MB
+
 fail=0
-for path in "${expect[@]}"; do
-  dir="/opt/tf-plugin-cache/${path}/linux_${arch}"
-  bin=$(ls "${dir}"/terraform-provider-* 2>/dev/null | head -1 || true)
-  if [ -z "${bin}" ] || [ ! -x "${bin}" ]; then
-    echo "FAIL: missing or non-executable provider at ${dir}"
+case "${TF_PLUGIN_CACHE_DIR:-}" in
+  /opt/tf-plugin-cache) ;;
+  *)
+    echo "FAIL: TF_PLUGIN_CACHE_DIR=${TF_PLUGIN_CACHE_DIR:-<unset>} (want /opt/tf-plugin-cache)"
+    fail=1 ;;
+esac
+
+for row in "${expect[@]}"; do
+  read -r source version filename <<<"${row}"
+  dir="/opt/tf-plugin-cache/registry.terraform.io/${source}/${version}/linux_${arch}"
+
+  entries=("${dir}"/*)
+  if [ ${#entries[@]} -eq 0 ]; then
+    echo "FAIL: ${source}@${version}/linux_${arch}: directory empty or missing"
     fail=1
-  else
-    size=$(stat -c %s "${bin}")
-    echo "OK: ${path}/linux_${arch} (${size} bytes)"
+    continue
   fi
+
+  bin="${dir}/${filename}"
+  if [ ! -f "${bin}" ]; then
+    echo "FAIL: ${source}@${version}/linux_${arch}: expected ${filename}, got:"
+    printf "       %s\n" "${entries[@]##*/}"
+    fail=1
+    continue
+  fi
+  if [ ! -x "${bin}" ]; then
+    echo "FAIL: ${bin}: not executable"
+    fail=1
+    continue
+  fi
+
+  size=$(stat -c %s "${bin}")
+  if [ "${size}" -lt "${min_bytes}" ]; then
+    echo "FAIL: ${bin}: implausibly small (${size} bytes < ${min_bytes} floor)"
+    fail=1
+    continue
+  fi
+  echo "OK:   ${source}@${version}/linux_${arch} (${size} bytes)"
 done
-test -n "${TF_PLUGIN_CACHE_DIR:-}" || { echo "FAIL: TF_PLUGIN_CACHE_DIR not set"; fail=1; }
-echo "TF_PLUGIN_CACHE_DIR=${TF_PLUGIN_CACHE_DIR}"
 exit ${fail}
 '

--- a/scripts/smoke-tf-cache.sh
+++ b/scripts/smoke-tf-cache.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Verify that the mars image ships a populated terraform provider plugin
+# cache for the current arch. Fails if any expected provider binary is
+# missing or non-executable.
+set -euo pipefail
+
+IMAGE="${1:?usage: smoke-tf-cache.sh <image>}"
+
+docker run --rm --entrypoint /bin/bash "${IMAGE}" -c '
+set -euo pipefail
+arch=$(uname -m | sed -e s/x86_64/amd64/ -e s/aarch64/arm64/)
+expect=(
+  registry.terraform.io/hashicorp/aws/6.45.0
+  registry.terraform.io/hashicorp/google/6.10.0
+  registry.terraform.io/hashicorp/google-beta/6.10.0
+)
+fail=0
+for path in "${expect[@]}"; do
+  dir="/opt/tf-plugin-cache/${path}/linux_${arch}"
+  bin=$(ls "${dir}"/terraform-provider-* 2>/dev/null | head -1 || true)
+  if [ -z "${bin}" ] || [ ! -x "${bin}" ]; then
+    echo "FAIL: missing or non-executable provider at ${dir}"
+    fail=1
+  else
+    size=$(stat -c %s "${bin}")
+    echo "OK: ${path}/linux_${arch} (${size} bytes)"
+  fi
+done
+test -n "${TF_PLUGIN_CACHE_DIR:-}" || { echo "FAIL: TF_PLUGIN_CACHE_DIR not set"; fail=1; }
+echo "TF_PLUGIN_CACHE_DIR=${TF_PLUGIN_CACHE_DIR}"
+exit ${fail}
+'


### PR DESCRIPTION
## Summary

- Bake `hashicorp/aws@6.45.0`, `hashicorp/google@6.10.0`, and `hashicorp/google-beta@6.10.0` into the mars image at `/opt/tf-plugin-cache` and export `TF_PLUGIN_CACHE_DIR`, matching the pins in `insideout-terraform-presets/schemas/providers.tf`.
- `terraform init` now symlinks the per-arch provider dir out of the cache instead of downloading ~750 MB of AWS binary; Argo's default tar preserves the symlink so the artifact tarball shrinks from ~205 MB to ~263 bytes (measured locally).
- Per-arch warmup via `TARGETARCH` so each image only carries its own arch's providers.
- Image size delta (arm64 native build): **3.12 GB → 4.26 GB**.

## Test plan

- [x] `make build-arm64` succeeds locally with the new `tf-providers` stage
- [x] `./scripts/smoke-tf-cache.sh luthersystems/mars:<tag>` passes
- [x] Verified `terraform init` against the baked cache: `- Using hashicorp/aws v6.45.0 from the shared cache directory` (×3 providers); whole init runs in ~2.7s
- [x] Verified the per-arch dir under `.terraform/providers/` is a symlink to the cache and that default `tar -czf` produces a tiny archive (263 B vs. 205 MB with `--dereference`)
- [x] Verified SHA256 check on the warmup terraform binary actually executes during build
- [ ] CI smoke check passes on both `amd64` and `arm64` runners (this PR)

## Review notes

- `/review` findings (P0/P1): none. Two P2 drive-bys addressed: warmup terraform now SHA256-verified against HashiCorp's published manifest; CI image discovery uses explicit `${GITHUB_SHA}` tag.
- `qa-professor` findings on `scripts/smoke-tf-cache.sh`: addressed two P0s (filename glob was too loose; `ls | head` masked failures) and one P1 (`TF_PLUGIN_CACHE_DIR` value wasn't validated). Script now asserts exact filename per provider, requires a 50 MB size floor (catches stub regressions), and checks the env var equals `/opt/tf-plugin-cache`.

## Required follow-up

- **`insideout-terraform-presets`**: regenerate `schemas/.terraform.lock.hcl` with both `-platform=linux_amd64` and `-platform=linux_arm64` so consumer lockfiles inherit both `h1:` hashes. Without this, consumer `terraform init` will miss the cache on whichever arch their lockfile wasn't generated on and fall back to re-downloading from the registry (current behavior — no regression, just no win).
- Consumer repos (`reliable`, `ui-infrastructure`, …) will need to rerun `terraform providers lock -platform=linux_amd64 -platform=linux_arm64` and commit the updated lockfile to realize the speedup. README documents the command.

Closes #165