### PR TITLE
fix(helmcharts/oracle): probe URL ?oracle_only=true -> ?http_only=true + timeout 1->3

### DIFF
--- a/ansible-roles/helm_charts/files/helmcharts/oracle/templates/deployment.yaml
+++ b/ansible-roles/helm_charts/files/helmcharts/oracle/templates/deployment.yaml
@@ -38,11 +38,13 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /v1/{{ .Values.app.name }}/health_check{{ if .Values.oracleOnlyProbe }}?oracle_only=true{{ end }}
+              path: /v1/{{ .Values.app.name }}/health_check{{ if .Values.httpOnlyProbe }}?http_only=true{{ end }}
               port: http
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
-              path: /v1/{{ .Values.app.name }}/health_check{{ if .Values.oracleOnlyProbe }}?oracle_only=true{{ end }}
+              path: /v1/{{ .Values.app.name }}/health_check{{ if .Values.httpOnlyProbe }}?http_only=true{{ end }}
               port: http
+            timeoutSeconds: 3
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/ansible-roles/helm_charts/files/helmcharts/oracle/values.yaml
+++ b/ansible-roles/helm_charts/files/helmcharts/oracle/values.yaml
@@ -48,7 +48,7 @@ resources:
   #   cpu: 100m
   #   memory: 128Mi
 
-oracleOnlyProbe: true
+httpOnlyProbe: true
 
 serviceAccount:
   create: true


### PR DESCRIPTION
## Problem

The oracle chart's liveness/readiness probes pass `?oracle_only=true` to `/v1/<app>/health_check`. **That query parameter does not exist on the proto** — the field is `http_only`.

- Proto: `buf.build/.../healthcheck/v1/healthcheck.pb.go:80` — `HttpOnly bool`, no `oracle_only` field.
- Handler gate: `svc/oracle/oracle.go:302` — `if !req.GetHttpOnly() { phylumHealthCheck(...) }` — gate works, just never received the value.

grpc-gateway silently drops unknown query params, so the oracle handler ran the full health check including the ~1s shiroclient `phylumHealthCheck` call.

## Symptom (staging, 2026-05-24)

**6 umbrella-oracle restarts in 9 hours**, ~every 90 minutes. Pod logs show:

```
rpc_dur=1.007s rpc_method=/srvpb.v1.UIService/GetHealthCheck
no phylum version found
```

The `rpc_dur=1.007s` blows the default 1s probe timeout. The `no phylum version found` line proves shiroclient was actually being called (i.e. `?oracle_only=true` was a no-op). Kubelet marks pod unhealthy → restart → repeat.

## Fix

1. Send the correct query param: `?http_only=true` so the handler short-circuits past `phylumHealthCheck`.
2. Bump probe `timeoutSeconds` from the implicit 1s default to 3s — defence in depth so a GC pause doesn't bounce the pod even on the fast path.
3. Rename the values toggle `oracleOnlyProbe` -> `httpOnlyProbe` so chart and proto field share a name.

## Diff

- `templates/deployment.yaml`: `?oracle_only=true` -> `?http_only=true` on both probes; add `timeoutSeconds: 3` to both; rename template var.
- `values.yaml`: rename `oracleOnlyProbe: true` -> `httpOnlyProbe: true`.

`grep -rn "oracleOnlyProbe\|oracle_only" .` is now clean across the whole repo — only these two files referenced the old name.

## Rollout

After merge + new mars tag, ui-infrastructure bumps `.mars-version` to pick this up. Tracking in [ui-infrastructure#292](https://github.com/luthersystems/ui-infrastructure/issues/292).