### PR TITLE
fix(image): use filesystem_mirror for TF providers — symlinks not copies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,8 +97,14 @@ RUN cd /tmp \
   && unzip -d /usr/local/bin "terraform_${TF_WARMUP_VERSION}_linux_${TARGETARCH}.zip" \
   && rm "terraform_${TF_WARMUP_VERSION}_linux_${TARGETARCH}.zip" tf_SHA256SUMS
 
-# Provider versions are kept in sync with insideout-terraform-presets.
-# Bump these together with the presets repo to keep cache hits useful.
+# Provider versions are kept in sync with insideout-terraform-presets and the
+# sandbox-infrastructure-template .terraform.lock.hcl that runs inside this
+# image. Bump these together with those repos to keep cache hits useful.
+# Note: with the filesystem_mirror config in /etc/terraformrc below, terraform
+# inside this container will refuse to download these specific providers from
+# the registry, so version drift between bake and consumer lockfiles will fail
+# `terraform init` rather than silently download. That's intentional — it
+# forces a synchronous bump rather than masking a slow path.
 ARG AWS_PROVIDER_VERSION=6.45.0
 ARG GOOGLE_PROVIDER_VERSION=6.10.0
 
@@ -201,11 +207,23 @@ RUN mkdir -p /opt/tfenv/versions && chmod -R a+w /opt/tfenv/versions && echo 'tr
 ENV PATH="/opt/tfenv/bin:/opt/bin:${PATH}"
 
 # Pre-warmed terraform provider cache for the providers pinned by
-# insideout-terraform-presets. Consumers get cache hits as long as their
-# .terraform.lock.hcl carries linux_amd64 / linux_arm64 h1 hashes; otherwise
-# terraform falls back to downloading from the registry as before.
+# insideout-terraform-presets / sandbox-infrastructure-template.
 COPY --from=tf-providers /opt/tf-plugin-cache /opt/tf-plugin-cache
-ENV TF_PLUGIN_CACHE_DIR=/opt/tf-plugin-cache
+
+# Tell terraform to install the baked providers via a filesystem mirror rather
+# than the default TF_PLUGIN_CACHE_DIR path. With a filesystem_mirror, init
+# *symlinks* the per-arch provider binary into <workdir>/.terraform/providers/
+# instead of copying it. That keeps the per-arch provider binaries (~200 MB)
+# out of Argo's tar of /marsproject — see luthersystems/mars#168.
+# include/exclude is intentionally a per-provider list (not a wildcard) so
+# any other hashicorp/* provider still resolves via direct registry download.
+COPY etc/terraformrc /etc/terraformrc
+RUN chmod a+r /etc/terraformrc
+ENV TF_CLI_CONFIG_FILE=/etc/terraformrc
+# TF_PLUGIN_CACHE_DIR is intentionally NOT set here: with the filesystem_mirror
+# block in /etc/terraformrc, the cache_dir behavior is redundant and, on older
+# terraform versions, would re-introduce the copy-instead-of-symlink path for
+# providers that fall outside the mirror's include list.
 
 COPY --from=downloader /usr/local/bin/helm /opt/bin/helm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,12 +99,10 @@ RUN cd /tmp \
 
 # Provider versions are kept in sync with insideout-terraform-presets and the
 # sandbox-infrastructure-template .terraform.lock.hcl that runs inside this
-# image. Bump these together with those repos to keep cache hits useful.
-# Note: with the filesystem_mirror config in /etc/terraformrc below, terraform
-# inside this container will refuse to download these specific providers from
-# the registry, so version drift between bake and consumer lockfiles will fail
-# `terraform init` rather than silently download. That's intentional — it
-# forces a synchronous bump rather than masking a slow path.
+# image. Bump these together with those repos to keep mirror hits useful —
+# /etc/terraformrc below configures a filesystem_mirror for these exact
+# versions. Drift falls back to a slower direct registry download (see the
+# etc/terraformrc comments), it does not break init.
 ARG AWS_PROVIDER_VERSION=6.45.0
 ARG GOOGLE_PROVIDER_VERSION=6.10.0
 
@@ -212,11 +210,13 @@ COPY --from=tf-providers /opt/tf-plugin-cache /opt/tf-plugin-cache
 
 # Tell terraform to install the baked providers via a filesystem mirror rather
 # than the default TF_PLUGIN_CACHE_DIR path. With a filesystem_mirror, init
-# *symlinks* the per-arch provider binary into <workdir>/.terraform/providers/
-# instead of copying it. That keeps the per-arch provider binaries (~200 MB)
-# out of Argo's tar of /marsproject — see luthersystems/mars#168.
-# include/exclude is intentionally a per-provider list (not a wildcard) so
-# any other hashicorp/* provider still resolves via direct registry download.
+# *symlinks* the per-arch provider directory into <workdir>/.terraform/
+# providers/ instead of copying its contents. That keeps the per-arch provider
+# binaries (~200 MB) out of Argo's tar of /marsproject — see
+# luthersystems/mars#168. include is a per-provider list (not a wildcard) and
+# the direct{} block is permissive so any other hashicorp/* provider, or a
+# version of these providers that drifts from the bake, still resolves via
+# direct registry download.
 COPY etc/terraformrc /etc/terraformrc
 RUN chmod a+r /etc/terraformrc
 ENV TF_CLI_CONFIG_FILE=/etc/terraformrc

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ clean:
 	rm -rf build
 
 build-%: LOADARG=$(if $(findstring $*,${LOCALARCH}),--load)
-build-%: Dockerfile go.mod go.sum ${GO_SOURCES} ${ANSIBLE_ROLES} ${ANSIBLE_PLUGINS} ${GRAFANA_DASHBOARDS} ssh_config requirements.txt
+build-%: Dockerfile go.mod go.sum ${GO_SOURCES} ${ANSIBLE_ROLES} ${ANSIBLE_PLUGINS} ${GRAFANA_DASHBOARDS} ssh_config requirements.txt etc/terraformrc
 	${DOCKER} buildx build \
 		--platform linux/$* \
 		--build-arg AWSCLI_VER=${AWSCLI_VERSION} \

--- a/README.md
+++ b/README.md
@@ -38,35 +38,41 @@ mars dev terraform -- providers --help
 
 ### Pre-warmed provider plugin cache
 
-The image sets `TF_PLUGIN_CACHE_DIR=/opt/tf-plugin-cache` and ships pre-warmed
-binaries for the providers pinned by `insideout-terraform-presets`:
+The image ships pre-warmed binaries for the providers pinned by
+`insideout-terraform-presets` / `sandbox-infrastructure-template` at
+`/opt/tf-plugin-cache`:
 
 - `hashicorp/aws`
 - `hashicorp/google`
 - `hashicorp/google-beta`
 
-`terraform init` will symlink these into `.terraform/providers/` instead of
-downloading them, which both speeds up `init` and keeps Argo workflow artifact
-tarballs small (symlinks archive as a few bytes instead of ~1 GB of provider
-binary).
+The image's `/etc/terraformrc` (selected via `TF_CLI_CONFIG_FILE`) configures a
+`filesystem_mirror` for those three providers. `terraform init` **symlinks**
+the per-arch provider binary out of `/opt/tf-plugin-cache` into
+`<workdir>/.terraform/providers/...` rather than copying it. That keeps the
+per-arch provider binaries (~200 MB) out of Argo workflow artifact tarballs of
+`/marsproject` — the receiving pod runs the same mars image and resolves the
+symlink against its own `/opt/tf-plugin-cache`.
 
-**Lockfile requirement.** Terraform validates cache hits against the `h1:`
-hashes in `.terraform.lock.hcl`. By default a lockfile only carries the hash
-for the platform `terraform init` was run on, so a Mac-generated lockfile will
-miss the Linux cache. To get cache hits in both the amd64 and arm64 mars
-images, regenerate consumer lockfiles with both Linux platforms:
+**Version drift falls back to download.** If a consumer's `.terraform.lock.hcl`
+pins a version of one of these providers that isn't in `/opt/tf-plugin-cache`,
+terraform falls through to the `direct` installation method and downloads from
+the registry — same behavior as before this image's cache existed (just
+slower than the mirror path). For maximum cache hits, bump
+`AWS_PROVIDER_VERSION` / `GOOGLE_PROVIDER_VERSION` in the Dockerfile in
+lockstep with consumer lockfile pins, then cut a new mars tag. All other
+hashicorp providers (`random`, `null`, `time`, `tls`, ...) always resolve via
+direct registry download as before.
+
+**Lockfile platform coverage.** A lockfile generated on macOS only carries
+`darwin_*` h1 hashes by default and will fail to validate the Linux cache hit.
+Regenerate consumer lockfiles with both Linux platforms so amd64 and arm64
+mars images can use the mirror:
 
 ```
 mars <env> terraform -- providers lock \
   -platform=linux_amd64 -platform=linux_arm64
 ```
-
-If the lockfile is missing the right hash, terraform falls back to downloading
-the provider from the registry — same behavior as before this cache existed.
-
-Provider versions are pinned at build time via `AWS_PROVIDER_VERSION` and
-`GOOGLE_PROVIDER_VERSION` ARGs in the Dockerfile. Bump them in lockstep with
-`insideout-terraform-presets`.
 
 # Setting up managed repositories
 

--- a/etc/terraformrc
+++ b/etc/terraformrc
@@ -1,0 +1,44 @@
+# Baked into the mars container at /etc/terraformrc; selected via
+# TF_CLI_CONFIG_FILE in the Dockerfile.
+#
+# Purpose: get terraform to *symlink* the AWS / GCP providers out of
+# /opt/tf-plugin-cache instead of copying them into the workdir's
+# .terraform/providers/ tree. With copies, Argo's tar of /marsproject ends up
+# archiving ~200 MB of per-arch provider binaries per workflow step
+# (5x tar slowdown — see luthersystems/mars#168). With a filesystem_mirror,
+# terraform writes symlinks; Argo's default tar preserves them; the receiving
+# pod (also the mars image, with the same /opt/tf-plugin-cache) resolves
+# them transparently.
+#
+# Why a `filesystem_mirror` block instead of just `plugin_cache_dir`:
+# the default TF_PLUGIN_CACHE_DIR path *copies* providers into the workdir
+# (or symlinks only with the experimental
+# `plugin_cache_may_break_dependency_lock_file = true`). `filesystem_mirror`
+# unconditionally symlinks on platforms that support it (Linux does), which
+# is the whole goal of #168.
+#
+# include is a per-provider list (not a wildcard) so any other hashicorp/*
+# provider — random, null, time, tls, etc. — still resolves via direct
+# registry download via the implicit installation method below.
+#
+# `direct` is intentionally left permissive (no `exclude` block): if a
+# consumer's `.terraform.lock.hcl` pins a version of aws / google /
+# google-beta that is not in /opt/tf-plugin-cache, terraform falls back to
+# registry download (same behavior as before this image's cache existed)
+# instead of failing init. That keeps version drift between this image and
+# downstream consumers' lockfiles operationally safe — at the cost of a
+# slower init on the drift case. When the bake versions are aligned with
+# the consumer's lockfile pins, terraform takes the fast symlink path; when
+# they're not, terraform takes the slow download path (no breakage).
+
+provider_installation {
+  filesystem_mirror {
+    path = "/opt/tf-plugin-cache"
+    include = [
+      "registry.terraform.io/hashicorp/aws",
+      "registry.terraform.io/hashicorp/google",
+      "registry.terraform.io/hashicorp/google-beta",
+    ]
+  }
+  direct {}
+}

--- a/scripts/smoke-tf-cache.sh
+++ b/scripts/smoke-tf-cache.sh
@@ -93,18 +93,28 @@ done
 # terraform symlink (not copy) the provider into a workdir .terraform/.
 # This is the whole point of #168.
 #
-# The final image does not preinstall terraform (consumers pick a version via
-# tfenv at runtime). Install the same throwaway version we used to warm the
-# cache so the symlink check works.
-if ! command -v terraform >/dev/null 2>&1; then
-  if command -v tfenv >/dev/null 2>&1; then
-    tfenv install 1.9.8 >/dev/null 2>&1 || true
-    tfenv use 1.9.8 >/dev/null 2>&1 || true
+# The final image does not preinstall terraform (the `terraform` on PATH is a
+# tfenv shim that requires a version to be installed and selected). Install
+# the same throwaway version we used to warm the cache so the symlink check
+# works.
+have_tf=0
+if command -v tfenv >/dev/null 2>&1; then
+  # `tfenv install <ver>` writes under /opt/tfenv/versions/ (world-writable).
+  # `tfenv use <ver>` would write /opt/tfenv/version (the global selector
+  # file) which is NOT world-writable in the mars image, so we set the
+  # per-shell override env var instead. The tfenv shim respects it.
+  if tfenv install 1.9.8 >/dev/null 2>&1; then
+    export TFENV_TERRAFORM_VERSION=1.9.8
+    have_tf=1
   fi
+elif command -v terraform >/dev/null 2>&1; then
+  # Non-tfenv image (unexpected — final image installs tfenv) — try whatever
+  # is on PATH.
+  have_tf=1
 fi
 
-if ! command -v terraform >/dev/null 2>&1; then
-  echo "FAIL: no terraform available for symlink E2E test (tfenv install failed?)"
+if [ "${have_tf}" -ne 1 ]; then
+  echo "FAIL: no terraform available for symlink E2E test (tfenv install/use failed?)"
   fail=1
 else
   workdir=$(mktemp -d)
@@ -128,19 +138,28 @@ EOF
       grep -E "^- " /tmp/tfinit.log || true
       fail=1
     fi
-    bin_path="${workdir}/.terraform/providers/registry.terraform.io/hashicorp/aws/6.45.0/linux_${arch}/terraform-provider-aws_v6.45.0_x5"
-    if [ ! -e "${bin_path}" ]; then
-      echo "FAIL: expected provider entry not present at ${bin_path}"
-      ls -la "${workdir}/.terraform/providers/registry.terraform.io/hashicorp/aws/6.45.0/linux_${arch}/" 2>&1 || true
+    # terraform symlinks the per-arch *directory* (not each provider binary
+    # individually) from the filesystem_mirror into the workdir. See
+    # internal/providercache/package_install.go installFromLocalDir.
+    arch_dir="${workdir}/.terraform/providers/registry.terraform.io/hashicorp/aws/6.45.0/linux_${arch}"
+    if [ ! -e "${arch_dir}" ]; then
+      echo "FAIL: expected provider dir not present at ${arch_dir}"
+      find "${workdir}/.terraform/providers" -maxdepth 6 2>&1 || true
       fail=1
-    elif [ ! -L "${bin_path}" ]; then
-      echo "FAIL: provider at ${bin_path} is a regular file, not a symlink (filesystem_mirror is meant to symlink)"
-      ls -la "${bin_path}" 2>&1
+    elif [ ! -L "${arch_dir}" ]; then
+      echo "FAIL: provider dir ${arch_dir} is a real directory, not a symlink (filesystem_mirror is meant to symlink — Argo tar will duplicate the binary)"
+      ls -la "$(dirname "${arch_dir}")" 2>&1
       fail=1
     else
-      target=$(readlink "${bin_path}")
+      target=$(readlink "${arch_dir}")
       case "${target}" in
-        /opt/tf-plugin-cache/*) echo "OK:   terraform init symlinked aws provider into workdir (-> ${target})" ;;
+        /opt/tf-plugin-cache/*)
+          echo "OK:   terraform init symlinked aws/linux_${arch} into workdir (-> ${target})"
+          # Sanity-check the symlink resolves to the actual provider binary.
+          if [ ! -x "${arch_dir}/terraform-provider-aws_v6.45.0_x5" ]; then
+            echo "FAIL: symlink resolves but expected binary missing or not executable"
+            fail=1
+          fi ;;
         *)
           echo "FAIL: symlink target does not point into /opt/tf-plugin-cache: ${target}"
           fail=1 ;;

--- a/scripts/smoke-tf-cache.sh
+++ b/scripts/smoke-tf-cache.sh
@@ -18,6 +18,8 @@ shopt -s nullglob
 arch=$(uname -m | sed -e s/x86_64/amd64/ -e s/aarch64/arm64/)
 
 # (provider-source, version, expected filename in the per-arch dir)
+# Keep these in sync with the AWS_PROVIDER_VERSION / GOOGLE_PROVIDER_VERSION
+# build args in the Dockerfile.
 expect=(
   "hashicorp/aws         6.45.0 terraform-provider-aws_v6.45.0_x5"
   "hashicorp/google      6.10.0 terraform-provider-google_v6.10.0_x5"
@@ -30,12 +32,29 @@ expect=(
 min_bytes=50000000  # 50 MB
 
 fail=0
-case "${TF_PLUGIN_CACHE_DIR:-}" in
-  /opt/tf-plugin-cache) ;;
+# TF_PLUGIN_CACHE_DIR is intentionally unset under the filesystem_mirror
+# regime (see luthersystems/mars#168). Confirm the env var is NOT set so we
+# do not regress to the copy-instead-of-symlink path.
+if [ -n "${TF_PLUGIN_CACHE_DIR:-}" ]; then
+  echo "FAIL: TF_PLUGIN_CACHE_DIR=${TF_PLUGIN_CACHE_DIR} should be unset (filesystem_mirror handles caching now)"
+  fail=1
+fi
+
+# Confirm TF_CLI_CONFIG_FILE points at the baked terraformrc.
+case "${TF_CLI_CONFIG_FILE:-}" in
+  /etc/terraformrc) ;;
   *)
-    echo "FAIL: TF_PLUGIN_CACHE_DIR=${TF_PLUGIN_CACHE_DIR:-<unset>} (want /opt/tf-plugin-cache)"
+    echo "FAIL: TF_CLI_CONFIG_FILE=${TF_CLI_CONFIG_FILE:-<unset>} (want /etc/terraformrc)"
     fail=1 ;;
 esac
+
+if [ ! -r /etc/terraformrc ]; then
+  echo "FAIL: /etc/terraformrc missing or not readable"
+  fail=1
+elif ! grep -q "filesystem_mirror" /etc/terraformrc; then
+  echo "FAIL: /etc/terraformrc does not contain a filesystem_mirror block"
+  fail=1
+fi
 
 for row in "${expect[@]}"; do
   read -r source version filename <<<"${row}"
@@ -69,5 +88,68 @@ for row in "${expect[@]}"; do
   fi
   echo "OK:   ${source}@${version}/linux_${arch} (${size} bytes)"
 done
+
+# End-to-end check: prove the filesystem_mirror config actually makes
+# terraform symlink (not copy) the provider into a workdir .terraform/.
+# This is the whole point of #168.
+#
+# The final image does not preinstall terraform (consumers pick a version via
+# tfenv at runtime). Install the same throwaway version we used to warm the
+# cache so the symlink check works.
+if ! command -v terraform >/dev/null 2>&1; then
+  if command -v tfenv >/dev/null 2>&1; then
+    tfenv install 1.9.8 >/dev/null 2>&1 || true
+    tfenv use 1.9.8 >/dev/null 2>&1 || true
+  fi
+fi
+
+if ! command -v terraform >/dev/null 2>&1; then
+  echo "FAIL: no terraform available for symlink E2E test (tfenv install failed?)"
+  fail=1
+else
+  workdir=$(mktemp -d)
+  pushd "${workdir}" >/dev/null
+  cat >main.tf <<EOF
+terraform {
+  required_providers {
+    aws = { source = "hashicorp/aws", version = "= 6.45.0" }
+  }
+}
+EOF
+  if ! terraform init -input=false -backend=false >/tmp/tfinit.log 2>&1; then
+    echo "FAIL: terraform init failed:"
+    cat /tmp/tfinit.log
+    fail=1
+  else
+    # "- Downloaded ..." indicates a registry fetch; mirror hits produce
+    # "- Installing ..." / "- Installed ..." only.
+    if grep -E "^- Downloaded" /tmp/tfinit.log >/dev/null; then
+      echo "FAIL: terraform init still downloaded providers (expected mirror hit):"
+      grep -E "^- " /tmp/tfinit.log || true
+      fail=1
+    fi
+    bin_path="${workdir}/.terraform/providers/registry.terraform.io/hashicorp/aws/6.45.0/linux_${arch}/terraform-provider-aws_v6.45.0_x5"
+    if [ ! -e "${bin_path}" ]; then
+      echo "FAIL: expected provider entry not present at ${bin_path}"
+      ls -la "${workdir}/.terraform/providers/registry.terraform.io/hashicorp/aws/6.45.0/linux_${arch}/" 2>&1 || true
+      fail=1
+    elif [ ! -L "${bin_path}" ]; then
+      echo "FAIL: provider at ${bin_path} is a regular file, not a symlink (filesystem_mirror is meant to symlink)"
+      ls -la "${bin_path}" 2>&1
+      fail=1
+    else
+      target=$(readlink "${bin_path}")
+      case "${target}" in
+        /opt/tf-plugin-cache/*) echo "OK:   terraform init symlinked aws provider into workdir (-> ${target})" ;;
+        *)
+          echo "FAIL: symlink target does not point into /opt/tf-plugin-cache: ${target}"
+          fail=1 ;;
+      esac
+    fi
+  fi
+  popd >/dev/null
+  rm -rf "${workdir}"
+fi
+
 exit ${fail}
 '

--- a/scripts/smoke-tf-cache.sh
+++ b/scripts/smoke-tf-cache.sh
@@ -1,12 +1,20 @@
 #!/usr/bin/env bash
 # Verify that the mars image ships a populated terraform provider plugin
-# cache for the current arch with the exact provider versions we expect.
+# cache for the current arch with the exact provider versions we expect AND
+# that the baked /etc/terraformrc makes `terraform init` symlink (not copy)
+# the per-arch provider directory into a workdir .terraform/providers/ tree.
+# See luthersystems/mars#168 for why the symlink behavior matters.
+#
 # Fails on:
-#   - missing or non-executable provider binary at the expected path
-#   - filename mismatch (wrong version or wrong provider)
-#   - more than one binary in the per-arch directory (cache shape unexpected)
-#   - implausibly small binary (build copied a stub)
-#   - TF_PLUGIN_CACHE_DIR unset or pointing somewhere unexpected
+#   - missing or non-executable provider binary at the expected cache path
+#   - filename / version mismatch in /opt/tf-plugin-cache
+#   - implausibly small provider binary (build copied a stub)
+#   - TF_PLUGIN_CACHE_DIR set (the filesystem_mirror config supersedes it)
+#   - TF_CLI_CONFIG_FILE not pointing at /etc/terraformrc
+#   - /etc/terraformrc missing or not containing a filesystem_mirror block
+#   - terraform init producing "Downloaded" lines instead of mirror hits
+#   - the per-arch provider dir in the workdir being a real directory (i.e.
+#     copy) instead of a symlink into /opt/tf-plugin-cache
 set -euo pipefail
 
 IMAGE="${1:?usage: smoke-tf-cache.sh <image>}"


### PR DESCRIPTION
## Summary

[mars v0.103.0 / #166](https://github.com/luthersystems/mars/pull/166) baked AWS/GCP providers into `/opt/tf-plugin-cache` with `TF_PLUGIN_CACHE_DIR` set. That eliminated the registry download but left providers being **COPIED** into `<workdir>/.terraform/providers/...` (terraform's default `TF_PLUGIN_CACHE_DIR` behavior). Argo's tar of `/marsproject` still had to archive ~200 MB of per-arch provider binaries per workflow step.

Switch to a `filesystem_mirror` provider installation method via `/etc/terraformrc` (selected with `TF_CLI_CONFIG_FILE`). Terraform unconditionally **symlinks** the per-arch provider directory from the mirror on Linux, so the provider binaries stay in `/opt/tf-plugin-cache` and only thin symlinks land in `/marsproject`. Argo's default tar preserves symlinks; the receiving pod (also the mars image with the same `/opt/tf-plugin-cache`) resolves them transparently.

## Measured impact on staging (pcs-647e1dd9-sswb7, 2026-05-25)

| Stage | Pre-v0.103.0 (no bake) | v0.103.0 (cache + copy) | After this PR (symlink) |
|---|---|---|---|
| `prepare-custom-stack` tar | **265s** (4m 25s), 1235 files | **52s**, 1264 files | expect <15s, ~1264 files |
| `tf-plan-all` file count | 3053 (1789-file delta = provider binaries) | 3053 (same) | expect ~1264 (delta gone) |
| Registry download per init | 90-120s | 0s | 0s |

### Local smoke-test confirmation

Built `luthersystems/mars:test168` from this branch (linux/arm64) and ran `terraform init` against a 3-provider config inside the container:

```
$ ./scripts/smoke-tf-cache.sh luthersystems/mars:test168
OK:   hashicorp/aws@6.45.0/linux_arm64 (787153058 bytes)
OK:   hashicorp/google@6.10.0/linux_arm64 (101580800 bytes)
OK:   hashicorp/google-beta@6.10.0/linux_arm64 (107675648 bytes)
OK:   terraform init symlinked aws/linux_arm64 into workdir
      (-> /opt/tf-plugin-cache/registry.terraform.io/hashicorp/aws/6.45.0/linux_arm64)
```

The per-arch directory is a symlink (`ls -la` shows `lrwxrwxrwx ... linux_arm64 -> /opt/tf-plugin-cache/...`), not a real directory.

`tar` size of the workdir (aws + google + google-beta) **with symlink preservation = 20 KB / 15 entries** vs. **with `--dereference` = 996 MB**. That's the eliminated provider-binary duplication.

## Design choices

- **`include` is a per-provider list, not a wildcard.** Only `hashicorp/{aws,google,google-beta}` go through the mirror. Other providers customer stacks pin (`hashicorp/{random,null,time,tls,http,kubernetes}`) still resolve via the implicit `direct {}` registry fallback.
- **`direct` block is permissive** (no `exclude`). A customer-pinned provider version that drifts from the bake falls back to registry download rather than failing init. Slower on the drift case; never silently breaks.
- **`TF_PLUGIN_CACHE_DIR` env removed**, intentionally. With the mirror config it's redundant; on older terraform versions it would re-introduce the copy-vs-symlink path.
- **Provider versions NOT bumped** in this PR. The current bake (`aws@6.45.0`, `google@6.10.0`, `google-beta@6.10.0`) stays. Note: the current sandbox-infrastructure-template `.terraform.lock.hcl` pins `aws@6.15.0` / `google@7.16.0`, so until that lockfile is bumped (or the bake is) the symlink path won't hit for the real production tf; the permissive `direct` block means it cleanly falls back to registry download in the meantime. Version alignment is a separate concern.

## Files

- `Dockerfile` — COPY etc/terraformrc, set `TF_CLI_CONFIG_FILE`, drop `TF_PLUGIN_CACHE_DIR`
- `etc/terraformrc` (new) — the `provider_installation` block with mirror config + extensive design comments
- `Makefile` — add `etc/terraformrc` to build trigger deps
- `scripts/smoke-tf-cache.sh` — extended to verify symlink behavior (image-time smoke test)
- `README.md` — updated to reflect the new TF_CLI_CONFIG_FILE-based config

## Test plan

- [x] Local Dockerfile builds cleanly on arm64
- [x] Local `smoke-tf-cache.sh` passes against the built image (cache layout + symlink E2E)
- [ ] CI: amd64 + arm64 docker builds + smoke-tf-cache.sh pass on both arches
- [ ] Post-merge + new mars release + ui-core marsVersion bump: confirm staging `prepare-custom-stack` tar drops to <15s and post-init file count stays flat
- [ ] Coordinate with sandbox-infrastructure-template lockfile pins so the mirror path actually hits in production (separate PR)

Closes [#168](https://github.com/luthersystems/mars/issues/168).