### PR TITLE
chore: bump baked aws provider to 6.46.0 and pre-install tfenv 1.9.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ RUN cd /tmp \
 # /etc/terraformrc below configures a filesystem_mirror for these exact
 # versions. Drift falls back to a slower direct registry download (see the
 # etc/terraformrc comments), it does not break init.
-ARG AWS_PROVIDER_VERSION=6.45.0
+ARG AWS_PROVIDER_VERSION=6.46.0
 ARG GOOGLE_PROVIDER_VERSION=6.10.0
 
 RUN mkdir -p ${TF_PLUGIN_CACHE_DIR} /tmp/warmup
@@ -203,6 +203,24 @@ COPY grafana-dashboards /opt/grafana-dashboards
 COPY --from=downloader /tmp/tfenv /opt/tfenv
 RUN mkdir -p /opt/tfenv/versions && chmod -R a+w /opt/tfenv/versions && echo 'trust-tfenv: yes' > /opt/tfenv/use-gpgv
 ENV PATH="/opt/tfenv/bin:/opt/bin:${PATH}"
+
+# Pre-install the terraform versions commonly requested by consumers via
+# `.terraform-version`. Without this, each Argo pod's first `tfenv install`
+# round-trips to releases.hashicorp.com (download tarball + SHA + GPG verify
+# + unzip) — observed at ~30s per pod, which is pure dead time when the
+# version doesn't change.
+#
+# Default tracks TF_WARMUP_VERSION (1.9.8) — the same terraform used to warm
+# the plugin cache in the tf-providers stage, and the version consumers
+# (e.g. sandbox-infrastructure-template) should pin to in their
+# `.terraform-version` to get a cache hit. Consumers pinned to a different
+# version still work — tfenv falls back to downloading at runtime — this is
+# a fast-path, not a hard pin.
+ARG TFENV_PREINSTALL_VERSIONS="1.9.8"
+RUN for v in ${TFENV_PREINSTALL_VERSIONS}; do \
+    /opt/tfenv/bin/tfenv install "$v" \
+    && chmod -R a+rX /opt/tfenv/versions/$v ; \
+  done
 
 # Pre-warmed terraform provider cache for the providers pinned by
 # insideout-terraform-presets / sandbox-infrastructure-template.

--- a/scripts/smoke-tf-cache.sh
+++ b/scripts/smoke-tf-cache.sh
@@ -29,7 +29,7 @@ arch=$(uname -m | sed -e s/x86_64/amd64/ -e s/aarch64/arm64/)
 # Keep these in sync with the AWS_PROVIDER_VERSION / GOOGLE_PROVIDER_VERSION
 # build args in the Dockerfile.
 expect=(
-  "hashicorp/aws         6.45.0 terraform-provider-aws_v6.45.0_x5"
+  "hashicorp/aws         6.46.0 terraform-provider-aws_v6.46.0_x5"
   "hashicorp/google      6.10.0 terraform-provider-google_v6.10.0_x5"
   "hashicorp/google-beta 6.10.0 terraform-provider-google-beta_v6.10.0_x5"
 )
@@ -97,14 +97,31 @@ for row in "${expect[@]}"; do
   echo "OK:   ${source}@${version}/linux_${arch} (${size} bytes)"
 done
 
+# Verify pre-installed tfenv versions are present so first-time `tfenv
+# install <v>` is a no-op at runtime (saves ~30s/pod that would otherwise
+# go to downloading the terraform release tarball + verify + unzip). Keep
+# in sync with TFENV_PREINSTALL_VERSIONS in the Dockerfile.
+expect_tfenv=(
+  "1.9.8"
+)
+for v in "${expect_tfenv[@]}"; do
+  if [ -x "/opt/tfenv/versions/${v}/terraform" ]; then
+    echo "OK:   tfenv pre-installed terraform v${v}"
+  else
+    echo "FAIL: tfenv missing pre-installed terraform v${v} at /opt/tfenv/versions/${v}/terraform"
+    fail=1
+  fi
+done
+
 # End-to-end check: prove the filesystem_mirror config actually makes
 # terraform symlink (not copy) the provider into a workdir .terraform/.
 # This is the whole point of #168.
 #
-# The final image does not preinstall terraform (the `terraform` on PATH is a
-# tfenv shim that requires a version to be installed and selected). Install
-# the same throwaway version we used to warm the cache so the symlink check
-# works.
+# Uses 1.9.8 — the version pre-installed in /opt/tfenv/versions/. With the
+# pre-install above, `tfenv install 1.9.8` is a no-op rather than the
+# ~30s download + verify + unzip dance. Keeps the smoke test path
+# consistent with what real consumers (sandbox-infrastructure-template)
+# do at runtime via their .terraform-version pin.
 have_tf=0
 if command -v tfenv >/dev/null 2>&1; then
   # `tfenv install <ver>` writes under /opt/tfenv/versions/ (world-writable).
@@ -130,7 +147,7 @@ else
   cat >main.tf <<EOF
 terraform {
   required_providers {
-    aws = { source = "hashicorp/aws", version = "= 6.45.0" }
+    aws = { source = "hashicorp/aws", version = "= 6.46.0" }
   }
 }
 EOF
@@ -149,7 +166,7 @@ EOF
     # terraform symlinks the per-arch *directory* (not each provider binary
     # individually) from the filesystem_mirror into the workdir. See
     # internal/providercache/package_install.go installFromLocalDir.
-    arch_dir="${workdir}/.terraform/providers/registry.terraform.io/hashicorp/aws/6.45.0/linux_${arch}"
+    arch_dir="${workdir}/.terraform/providers/registry.terraform.io/hashicorp/aws/6.46.0/linux_${arch}"
     if [ ! -e "${arch_dir}" ]; then
       echo "FAIL: expected provider dir not present at ${arch_dir}"
       find "${workdir}/.terraform/providers" -maxdepth 6 2>&1 || true
@@ -164,7 +181,7 @@ EOF
         /opt/tf-plugin-cache/*)
           echo "OK:   terraform init symlinked aws/linux_${arch} into workdir (-> ${target})"
           # Sanity-check the symlink resolves to the actual provider binary.
-          if [ ! -x "${arch_dir}/terraform-provider-aws_v6.45.0_x5" ]; then
+          if [ ! -x "${arch_dir}/terraform-provider-aws_v6.46.0_x5" ]; then
             echo "FAIL: symlink resolves but expected binary missing or not executable"
             fail=1
           fi ;;


### PR DESCRIPTION
## Summary

- **aws provider bake**: `6.45.0 → 6.46.0` to match what reliable's composer (`hashicorp/aws >= 6.0`) resolves to today. Eliminates the version mismatch that was making `terraform init` fall back to `direct {}` registry download instead of the `filesystem_mirror` symlink path.
- **tfenv pre-install `1.9.8`**: pre-installs the same terraform version `TF_WARMUP_VERSION` already uses, so consumer pods don't pay the ~30s `tfenv install` download dance at runtime.
- **smoke test**: asserts both the baked aws 6.46.0 and the pre-installed `/opt/tfenv/versions/1.9.8/terraform`. The end-to-end "init must symlink not copy" check now uses 1.9.8 instead of installing it from scratch — so the test itself proves the pre-install works.

## Why now

The 2026-05-25 incident on `sess_v2_CnqUJ6NRJnLC` re-tested after [#168](https://github.com/luthersystems/mars/pull/168)'s symlink work landed showed the plan still copied 3123 files into Argo's output tar and uploaded ~750MB to S3. tflogs forensics on `pcs-647e1dd9-ghqs8`:

```
- Installing hashicorp/aws v6.46.0...      ← downloaded, NOT mirror hit
Taring /marsproject ... archived 3123 files/dirs   ← provider in the tar
```

Composer requests `>= 6.0`, terraform resolved that to the registry's latest = 6.46.0, mars only had 6.45.0 cached → `filesystem_mirror.include` matched on source but missed on version → `direct {}` fallback. Bumping the bake closes the gap.

## Test plan

- [x] `Dockerfile` edits reviewed
- [x] `scripts/smoke-tf-cache.sh` updated to pin the new aws version and assert pre-installed tfenv 1.9.8
- [ ] CI: image build + smoke test
- [ ] After this lands + I tag `v0.105.0` and ui-infra `.mars-version` bumps: re-run staging e2e against `sess_v2_CnqUJ6NRJnLC`. Expected: ~750MB provider binary stays in `/opt/tf-plugin-cache` (symlinked), Argo workflow tar shrinks to <1k files, S3 upload becomes near-instant.

## Required follow-up

After merge + tag:
1. luthersystems/insideout-terraform-presets composer: pin `hashicorp/aws "= 6.46.0"` (currently `">= 6.0"`) so a future 6.47.0 release doesn't silently re-introduce drift.
2. luthersystems/sandbox-infrastructure-template: `tf/custom-stack-provision/.terraform-version` `1.7.5 → 1.9.8` to match the pre-baked tfenv version.
3. luthersystems/ui-infrastructure `.mars-version` → `v0.105.0` and luthersystems/ui-core `marsVersion` const → `v0.105.0`.
4. luthersystems/reliable: bump `insideout-terraform-presets` in go.mod.