### PR TITLE
feat(helmcharts): publish ALB health-check annotations on umbrella subchart Services (#172)

### DIFF
--- a/ansible-roles/helm_charts/files/helmcharts/agentbuilder/templates/service.yaml
+++ b/ansible-roles/helm_charts/files/helmcharts/agentbuilder/templates/service.yaml
@@ -4,6 +4,15 @@ metadata:
   name: {{ include "agentbuilder.fullname" . }}
   labels:
     {{- include "agentbuilder.labels" . | nindent 4 }}
+  annotations:
+    alb.ingress.kubernetes.io/healthcheck-path: "/health"
+    alb.ingress.kubernetes.io/healthcheck-port: "traffic-port"
+    alb.ingress.kubernetes.io/healthcheck-protocol: "HTTP"
+    alb.ingress.kubernetes.io/success-codes: "200"
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: "15"
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
+    alb.ingress.kubernetes.io/healthy-threshold-count: "2"
+    alb.ingress.kubernetes.io/unhealthy-threshold-count: "3"
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/ansible-roles/helm_charts/files/helmcharts/connectorhub/templates/service.yaml
+++ b/ansible-roles/helm_charts/files/helmcharts/connectorhub/templates/service.yaml
@@ -4,6 +4,15 @@ metadata:
   name: {{ include "connectorhub.fullname" . }}
   labels:
     {{- include "connectorhub.labels" . | nindent 4 }}
+  annotations:
+    alb.ingress.kubernetes.io/healthcheck-path: "/v1/ch/health_check"
+    alb.ingress.kubernetes.io/healthcheck-port: "traffic-port"
+    alb.ingress.kubernetes.io/healthcheck-protocol: "HTTP"
+    alb.ingress.kubernetes.io/success-codes: "200"
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: "15"
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
+    alb.ingress.kubernetes.io/healthy-threshold-count: "2"
+    alb.ingress.kubernetes.io/unhealthy-threshold-count: "3"
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/ansible-roles/helm_charts/files/helmcharts/insideoutmcp/templates/service.yaml
+++ b/ansible-roles/helm_charts/files/helmcharts/insideoutmcp/templates/service.yaml
@@ -4,10 +4,18 @@ metadata:
   name: {{ include "insideoutmcp.fullname" . }}
   labels:
     {{- include "insideoutmcp.labels" . | nindent 4 }}
-  {{- with .Values.service.annotations }}
   annotations:
+    alb.ingress.kubernetes.io/healthcheck-path: "/healthz"
+    alb.ingress.kubernetes.io/healthcheck-port: "traffic-port"
+    alb.ingress.kubernetes.io/healthcheck-protocol: "HTTP"
+    alb.ingress.kubernetes.io/success-codes: "200"
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: "15"
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
+    alb.ingress.kubernetes.io/healthy-threshold-count: "2"
+    alb.ingress.kubernetes.io/unhealthy-threshold-count: "3"
+    {{- with .Values.service.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/ansible-roles/helm_charts/files/helmcharts/lutherauth/templates/service.yaml
+++ b/ansible-roles/helm_charts/files/helmcharts/lutherauth/templates/service.yaml
@@ -4,6 +4,15 @@ metadata:
   name: {{ include "lutherauth.fullname" . }}
   labels:
     {{- include "lutherauth.labels" . | nindent 4 }}
+  annotations:
+    alb.ingress.kubernetes.io/healthcheck-path: "/v1/auth/.well-known/jwks.json"
+    alb.ingress.kubernetes.io/healthcheck-port: "traffic-port"
+    alb.ingress.kubernetes.io/healthcheck-protocol: "HTTP"
+    alb.ingress.kubernetes.io/success-codes: "200"
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: "15"
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
+    alb.ingress.kubernetes.io/healthy-threshold-count: "2"
+    alb.ingress.kubernetes.io/unhealthy-threshold-count: "3"
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/ansible-roles/helm_charts/files/helmcharts/oracle/templates/service.yaml
+++ b/ansible-roles/helm_charts/files/helmcharts/oracle/templates/service.yaml
@@ -7,6 +7,14 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: {{ .Values.ports.metrics | quote }}
+    alb.ingress.kubernetes.io/healthcheck-path: '/v1/{{ .Values.app.name }}/health_check{{ if .Values.httpOnlyProbe }}?http_only=true{{ end }}'
+    alb.ingress.kubernetes.io/healthcheck-port: "traffic-port"
+    alb.ingress.kubernetes.io/healthcheck-protocol: "HTTP"
+    alb.ingress.kubernetes.io/success-codes: "200"
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: "15"
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
+    alb.ingress.kubernetes.io/healthy-threshold-count: "2"
+    alb.ingress.kubernetes.io/unhealthy-threshold-count: "3"
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
Closes part of [#172](https://github.com/luthersystems/mars/issues/172). `connectordiscoverymcp` is intentionally not fixed here — the app has no readinessProbe / health endpoint yet, so adding the annotation alone would still fail. Tracked as a separate follow-up against the app repo.

## Why

`alb.ingress.kubernetes.io/healthcheck-path` is not set anywhere on the umbrella Ingress or Services, so the AWS Load Balancer Controller defaults to `GET / → 200`. Every umbrella backend serves `404 Not Found` for `GET /`, so 7 of 8 TGs report `Target.ResponseCodeMismatch`. ALB has been silently in fail-open mode for 3+ days. The K8s `readinessProbe` in each subchart's `deployment.yaml` already points at the real endpoint — this PR mirrors that path into ALB-controller annotations on the Service so the controller picks it up per-TG.

## What landed

One commit per subchart (5 total). Each renders cleanly under `helm template`.

| TG | Subchart Service | Pod port | HC path published |
|---|---|---|---|
| `k8s-ui-umbrella-6539a0bf27` | `umbrella-oracle` | 8080 | `/v1/{{ .Values.app.name }}/health_check?http_only=true` |
| `k8s-ui-umbrella-03eae6fb2c` | `umbrella-lutherauth` | 7070 | `/v1/auth/.well-known/jwks.json` |
| `k8s-ui-umbrella-48da82ab9f` | `umbrella-connectorhub` (port 80→8080) | 8080 | `/v1/ch/health_check` |
| `k8s-ui-umbrella-a6258428fd` | `umbrella-connectorhub` (port 81→8082) | 8082 | `/v1/ch/health_check` (same Service → same annotation) |
| `k8s-ui-umbrella-945c9cc598` | `umbrella-insideoutmcp` | 8080 | `/healthz` |
| `k8s-ui-umbrella-60e66ad143` | `umbrella-agentbuilder` | 8000 | `/health` |
| `k8s-ui-umbrella-9fb257ad5f` | `umbrella-connectordiscoverymcp` | 8000 | **not touched** — needs app-side `/health` first |
| `k8s-ui-umbrella-cce528566c` | `umbrella-insideoutmcp-grpc` | 9090 | **not touched** — already healthy via AWS gRPC default `/AWS.ALB/healthcheck` |

Annotation block per Service (HC path varies, everything else identical):

```yaml
alb.ingress.kubernetes.io/healthcheck-path: '<path-from-readinessProbe>'
alb.ingress.kubernetes.io/healthcheck-port: "traffic-port"
alb.ingress.kubernetes.io/healthcheck-protocol: "HTTP"
alb.ingress.kubernetes.io/success-codes: "200"
alb.ingress.kubernetes.io/healthcheck-interval-seconds: "15"
alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
alb.ingress.kubernetes.io/healthy-threshold-count: "2"
alb.ingress.kubernetes.io/unhealthy-threshold-count: "3"
```

Oracle's HC path is templated (`{{ .Values.app.name }}` + `{{ if .Values.httpOnlyProbe }}`) to stay in sync with the existing readinessProbe expression. Other charts have static paths in both the readinessProbe and the annotation.

## Discrepancies vs. issue text

None — every readinessProbe path matched the issue's mapping table.

## Test plan

- [ ] After merge, bump `mars` ref in [ui-infrastructure](https://github.com/luthersystems/ui-infrastructure) and reapply the umbrella playbook to `plt-or-test-main-eks-0`.
- [ ] `aws elbv2 describe-target-health --target-group-arn ...` on each of the 6 fixed TGs returns `healthy` (within 30s, given `healthy-threshold-count: 2` * `interval: 15s`).
- [ ] CloudWatch `HealthyHostCount` ≥ 1 on each TG.
- [ ] No regression in user-facing traffic (`https://insideout.luthersystemsapp.com/v1/ui/health_check` 200 from CF).
- [ ] Stage soak ≥ 24h before bumping mars in production.
- [ ] File a follow-up issue against the `connectordiscoverymcp` app repo to add `/health` + readinessProbe; once that lands, add the annotation block here too.