### PR TITLE
fix(connectordiscoverymcp): wire /healthz readiness probe + ALB HC annotation

### DIFF
--- a/ansible-roles/helm_charts/files/helmcharts/connectordiscoverymcp/templates/deployment.yaml
+++ b/ansible-roles/helm_charts/files/helmcharts/connectordiscoverymcp/templates/deployment.yaml
@@ -44,3 +44,19 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3

--- a/ansible-roles/helm_charts/files/helmcharts/connectordiscoverymcp/templates/service.yaml
+++ b/ansible-roles/helm_charts/files/helmcharts/connectordiscoverymcp/templates/service.yaml
@@ -4,6 +4,15 @@ metadata:
   name: {{ include "connectordiscoverymcp.fullname" . }}
   labels:
     {{- include "connectordiscoverymcp.labels" . | nindent 4 }}
+  annotations:
+    alb.ingress.kubernetes.io/healthcheck-path: "/healthz"
+    alb.ingress.kubernetes.io/healthcheck-port: "traffic-port"
+    alb.ingress.kubernetes.io/healthcheck-protocol: "HTTP"
+    alb.ingress.kubernetes.io/success-codes: "200"
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: "15"
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
+    alb.ingress.kubernetes.io/healthy-threshold-count: "2"
+    alb.ingress.kubernetes.io/unhealthy-threshold-count: "3"
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
## Summary

Completes the work started in [#173](https://github.com/luthersystems/mars/pull/173) for the last laggard target group, `connectordiscoverymcp`.

- Adds `readinessProbe` + `livenessProbe` on the container, both hitting `GET /healthz` on the `http` (8000) port. Previously there were no probes at all, so K8s reported the pod ready immediately on container start — masking a misconfigured / crashing supergateway.
- Adds the standard ALB health-check annotation block to the Service (same eight annotations and values as the sibling subcharts mars#173 wired up).

Pairs with [luthersystems/agent-builder#47](https://github.com/luthersystems/agent-builder/pull/47) which adds `--healthEndpoint /healthz` to the supergateway CMD in `agent-builder/connector-mcp/Dockerfile`. That PR is what actually makes `luthersystems/connector-mcp-discovery:latest` serve `GET /healthz → 200 "ok"`.

Closes [#172](https://github.com/luthersystems/mars/issues/172).

## DO NOT MERGE until upstream image ships

This PR **must not be merged** until:
1. The agent-builder companion PR is merged, AND
2. The new `luthersystems/connector-mcp-discovery:latest` image is live on Docker Hub.

If merged before that, the next umbrella deploy will roll a pod where the supergateway does not serve `/healthz`, the new readinessProbe will fail, the pod will never become Ready, and the ALB will pull traffic — taking the connector-discovery MCP surface down.

Rendered locally via `helm template` to confirm both probe blocks and the annotation block come out with the right indentation.

## Test plan

- [ ] Verify agent-builder companion PR merged + new `:latest` image timestamp on Docker Hub
- [ ] Merge this PR
- [ ] Cut mars release (next minor, probably v0.107.0)
- [ ] Bump `.mars-version` in ui-infrastructure → deploy umbrella on test
- [ ] `aws elbv2 describe-target-health` on `k8s-ui-umbrella-9fb257ad5f` → all targets `healthy`
- [ ] `kubectl -n ui exec deploy/umbrella-connectordiscoverymcp -- python3 -c 'import urllib.request; print(urllib.request.urlopen("http://localhost:8000/healthz", timeout=2).read())'` → `b'ok'`
