### PR TITLE
fix: serialize tfenv runtime installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,6 +147,7 @@ RUN apt update -y && apt install --no-install-recommends -yq \
   perl \
   python3 \
   rsync \
+  util-linux \
   unzip \
   gnupg
 
@@ -202,6 +203,9 @@ COPY grafana-dashboards /opt/grafana-dashboards
 
 COPY --from=downloader /tmp/tfenv /opt/tfenv
 RUN mkdir -p /opt/tfenv/versions && chmod -R a+w /opt/tfenv/versions && echo 'trust-tfenv: yes' > /opt/tfenv/use-gpgv
+RUN mv /opt/tfenv/bin/terraform /opt/tfenv/bin/terraform.tfenv-original
+COPY scripts/tfenv-terraform-lock-wrapper.sh /opt/tfenv/bin/terraform
+RUN chmod a+x /opt/tfenv/bin/terraform /opt/tfenv/bin/terraform.tfenv-original
 ENV PATH="/opt/tfenv/bin:/opt/bin:${PATH}"
 
 # Pre-install the terraform versions commonly requested by consumers via
@@ -211,11 +215,10 @@ ENV PATH="/opt/tfenv/bin:/opt/bin:${PATH}"
 # version doesn't change.
 #
 # Default tracks TF_WARMUP_VERSION (1.9.8) — the same terraform used to warm
-# the plugin cache in the tf-providers stage, and the version consumers
-# (e.g. sandbox-infrastructure-template) should pin to in their
-# `.terraform-version` to get a cache hit. Consumers pinned to a different
-# version still work — tfenv falls back to downloading at runtime — this is
-# a fast-path, not a hard pin.
+# the plugin cache in the tf-providers stage. Consumers pinned to a different
+# version still work: tfenv falls back to downloading at runtime under the
+# Mars wrapper's flock-guarded install path. This is a fast-path, not a hard
+# pin.
 ARG TFENV_PREINSTALL_VERSIONS="1.9.8"
 RUN for v in ${TFENV_PREINSTALL_VERSIONS}; do \
     /opt/tfenv/bin/tfenv install "$v" \

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -33,7 +33,7 @@ func TestTerraformPlanBuildsWorkspaceAndVarFiles(t *testing.T) {
 			t.Fatalf("exit code = %d, stderr:\n%s", code, stderr.String())
 		}
 		want := [][]string{
-			{"tfenv", "install"},
+			{"flock", "/opt/tfenv/versions/.install.lock", "tfenv", "install"},
 			{"terraform", "workspace", "show"},
 			{"terraform", "workspace", "select", "dev"},
 			{"terraform", "plan", "-var-file=vars/common/common.tfvars", "-var-file=vars/dev/dev.tfvars", "-destroy", "-out=plan.out", "-target", "module.a", "-target", "module.b", "-refresh-only"},

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -16,6 +16,8 @@ import (
 	"github.com/luthersystems/mars/internal/runner"
 )
 
+const tfenvInstallLockPath = "/opt/tfenv/versions/.install.lock"
+
 type InitCmd struct {
 	BackendConfig []string `name:"backend-config" help:"A backend config file or key=value assignment."`
 	Upgrade       bool     `name:"upgrade" help:"Upgrade modules and plugins."`
@@ -381,7 +383,11 @@ func (s *service) tfenvInit(ctx context.Context) error {
 	} else if err != nil {
 		return err
 	}
-	return s.sequence(ctx, runner.Cmd("tfenv", "install"))
+	return s.sequence(ctx, tfenvInstallCmd())
+}
+
+func tfenvInstallCmd() runner.Command {
+	return runner.Cmd("flock", tfenvInstallLockPath, "tfenv", "install")
 }
 
 func (s *service) checkEnv() error {

--- a/internal/terraform/terraform_test.go
+++ b/internal/terraform/terraform_test.go
@@ -51,11 +51,11 @@ func TestPlanApplyCreatesPlanPromptsAndAppliesAcceptedPlan(t *testing.T) {
 			t.Fatalf("plan path = %q, want generated .tf-plans/tf-plan-dev-123-*.out", planPath)
 		}
 		wantPrefix := [][]string{
-			{"tfenv", "install"},
+			{"flock", tfenvInstallLockPath, "tfenv", "install"},
 			{"terraform", "workspace", "show"},
 			{"terraform", "workspace", "select", "dev"},
 			{"terraform", "plan", "-var-file=vars/common/common.tfvars", "-var-file=vars/dev/dev.tfvars", planCmd[4]},
-			{"tfenv", "install"},
+			{"flock", tfenvInstallLockPath, "tfenv", "install"},
 			{"terraform", "workspace", "show"},
 			{"terraform", "workspace", "select", "dev"},
 			{"terraform", "apply", planPath},
@@ -85,11 +85,52 @@ func TestWorkspacePromptRejectsDefaultNo(t *testing.T) {
 			t.Fatalf("error = %v, want exit code 1", err)
 		}
 		want := [][]string{
-			{"tfenv", "install"},
+			{"flock", tfenvInstallLockPath, "tfenv", "install"},
 			{"terraform", "workspace", "show"},
 		}
 		if got := fake.Commands(); !reflect.DeepEqual(got, want) {
 			t.Fatalf("commands = %#v, want prompt to stop before apply\nrecords:\n%s", got, fake.Output())
+		}
+	})
+}
+
+func TestTfenvInitUsesFlockWhenTerraformVersionExists(t *testing.T) {
+	withProject(t, func() {
+		writeFile(t, ".terraform-version", "1.7.5\n")
+		fake := &runner.Fake{}
+		s := &service{
+			runner: fake,
+			stderr: &strings.Builder{},
+		}
+
+		if err := s.tfenvInit(context.Background()); err != nil {
+			t.Fatalf("tfenvInit failed: %v", err)
+		}
+
+		want := [][]string{{"flock", tfenvInstallLockPath, "tfenv", "install"}}
+		if got := fake.Commands(); !reflect.DeepEqual(got, want) {
+			t.Fatalf("commands = %#v, want locked tfenv install\nrecords:\n%s", got, fake.Output())
+		}
+	})
+}
+
+func TestTfenvInitSkipsInstallWhenTerraformVersionMissing(t *testing.T) {
+	withProject(t, func() {
+		fake := &runner.Fake{}
+		stderr := &strings.Builder{}
+		s := &service{
+			runner: fake,
+			stderr: stderr,
+		}
+
+		if err := s.tfenvInit(context.Background()); err != nil {
+			t.Fatalf("tfenvInit failed: %v", err)
+		}
+		if got := fake.Commands(); len(got) != 0 {
+			t.Fatalf("commands = %#v, want no tfenv install\nrecords:\n%s", got, fake.Output())
+		}
+		if !strings.Contains(stderr.String(), ".terraform-version not found") {
+			t.Fatalf("stderr = %q, want missing .terraform-version warning", stderr.String())
 		}
 	})
 }

--- a/scripts/smoke-tf-cache.sh
+++ b/scripts/smoke-tf-cache.sh
@@ -40,6 +40,20 @@ expect=(
 min_bytes=50000000  # 50 MB
 
 fail=0
+if command -v flock >/dev/null 2>&1; then
+  echo "OK:   flock available for tfenv install serialization"
+else
+  echo "FAIL: flock is missing"
+  fail=1
+fi
+
+if [ -x /opt/tfenv/bin/terraform.tfenv-original ] && grep -q "terraform.tfenv-original" /opt/tfenv/bin/terraform; then
+  echo "OK:   tfenv terraform shim is flock-guarded"
+else
+  echo "FAIL: tfenv terraform shim wrapper is missing or incomplete"
+  fail=1
+fi
+
 # TF_PLUGIN_CACHE_DIR is intentionally unset under the filesystem_mirror
 # regime (see luthersystems/mars#168). Confirm the env var is NOT set so we
 # do not regress to the copy-instead-of-symlink path.

--- a/scripts/tfenv-terraform-lock-wrapper.sh
+++ b/scripts/tfenv-terraform-lock-wrapper.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tfenv_root="${TFENV_ROOT:-/opt/tfenv}"
+versions_dir="${TFENV_VERSIONS_DIR:-${tfenv_root}/versions}"
+lock_path="${TFENV_INSTALL_LOCK_PATH:-${versions_dir}/.install.lock}"
+terraform_original="${tfenv_root}/bin/terraform.tfenv-original"
+
+version="$("${tfenv_root}/bin/tfenv" version-name 2>/dev/null || true)"
+if [ -n "${version}" ] && [ "${version}" != "system" ] && [ ! -x "${versions_dir}/${version}/terraform" ]; then
+  flock "${lock_path}" "${tfenv_root}/bin/tfenv" install "${version}"
+fi
+
+exec "${terraform_original}" "$@"


### PR DESCRIPTION
## Summary
- Wrap Mars-managed `tfenv install` calls with `flock` on the shared tfenv versions cache.
- Replace the image's `/opt/tfenv/bin/terraform` shim with a fast-path wrapper that locks and installs only when the selected version is missing, covering direct shim users like reverse import.
- Extend the image smoke checks to verify `flock` is available and the tfenv shim is guarded.

Closes #188

## Test plan
- [x] `go test ./internal/terraform ./internal/cli ./internal/reverseimportjob`
- [x] `bash -n scripts/tfenv-terraform-lock-wrapper.sh scripts/smoke-tf-cache.sh`
- [x] `git diff --check`
- [x] Fake tfenv-root hot-path check: installed version execs original shim without needing `flock`

## Security review
- No auth/API surface changes.
- New command execution uses fixed argv/script paths; no user-controlled shell evaluation.