### PR TITLE
feat(terraform): add `apply --forbid-resource-changes` guard

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.12
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1
+	github.com/hashicorp/terraform-json v0.27.2
 	github.com/joho/godotenv v1.5.1
 	github.com/luthersystems/insideout-terraform-presets v0.11.1-0.20260605233704-4ab729343696
 	github.com/sosedoff/ansible-vault-go v0.2.0
@@ -87,7 +88,6 @@ require (
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20260224005459-813a97530220 // indirect
 	github.com/hashicorp/terraform-exec v0.25.2 // indirect
-	github.com/hashicorp/terraform-json v0.27.2 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect

--- a/internal/terraform/forbid_resource_changes_test.go
+++ b/internal/terraform/forbid_resource_changes_test.go
@@ -1,0 +1,129 @@
+package terraform
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/mars/internal/app"
+	"github.com/luthersystems/mars/internal/runner"
+)
+
+// TestAssertNoResourceChanges pins the core classification: state-only plan
+// actions (no-op, read, forget) are allowed; any create/update/delete (incl.
+// replace) is refused.
+func TestAssertNoResourceChanges(t *testing.T) {
+	rc := func(addr string, actions ...string) string {
+		quoted := make([]string, len(actions))
+		for i, a := range actions {
+			quoted[i] = `"` + a + `"`
+		}
+		return `{"address":"` + addr + `","change":{"actions":[` + strings.Join(quoted, ",") + `]}}`
+	}
+	plan := func(changes ...string) []byte {
+		return []byte(`{"format_version":"1.2","resource_changes":[` + strings.Join(changes, ",") + `]}`)
+	}
+
+	cases := []struct {
+		name      string
+		json      []byte
+		wantErr   bool
+		errSubstr string
+	}{
+		{"empty plan", plan(), false, ""},
+		{"single forget", plan(rc("aws_s3_bucket.imp", "forget")), false, ""},
+		{"multiple forgets", plan(rc("aws_s3_bucket.a", "forget"), rc("aws_s3_bucket.b", "forget")), false, ""},
+		{"no-op", plan(rc("aws_s3_bucket.imp", "no-op")), false, ""},
+		{"read", plan(rc("data.aws_caller_identity.cur", "read")), false, ""},
+		{"create -> refuse", plan(rc("aws_iam_role.x", "create")), true, "aws_iam_role.x"},
+		{"update -> refuse", plan(rc("aws_s3_bucket.imp", "update")), true, "aws_s3_bucket.imp"},
+		{"delete -> refuse", plan(rc("aws_s3_bucket.imp", "delete")), true, "aws_s3_bucket.imp"},
+		{"replace -> refuse", plan(rc("aws_db_instance.db", "create", "delete")), true, "aws_db_instance.db"},
+		{"forget + create -> refuse names the create only", plan(rc("aws_s3_bucket.imp", "forget"), rc("aws_iam_role.x", "create")), true, "aws_iam_role.x"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := assertNoResourceChanges(&strings.Builder{}, tc.json)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tc.errSubstr) {
+					t.Fatalf("error %q does not mention %q", err.Error(), tc.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+
+	if err := assertNoResourceChanges(&strings.Builder{}, []byte("not json")); err == nil {
+		t.Fatalf("expected parse error on malformed plan json")
+	}
+	// A forget alongside a create must NOT be silently allowed: the create
+	// makes the whole apply unsafe.
+	if err := assertNoResourceChanges(&strings.Builder{}, []byte(`{"format_version":"1.2","resource_changes":[{"address":"x","change":{"actions":["forget"]}},{"address":"y","change":{"actions":["delete"]}}]}`)); err == nil || !strings.Contains(err.Error(), "y") {
+		t.Fatalf("forget+delete must be refused naming the delete; got %v", err)
+	}
+}
+
+// TestForbidResourceChanges_FlowBlocksOnChange verifies the guarded apply
+// inspects the plan and REFUSES (no `terraform apply` run) when the plan
+// would change a resource.
+func TestForbidResourceChanges_FlowBlocksOnChange(t *testing.T) {
+	withProject(t, func() {
+		writeFile(t, ".terraform-version", "1.7.5\n")
+		writeFile(t, "vars/dev/dev.tfvars", "")
+		planJSON := []byte(`{"format_version":"1.2","resource_changes":[{"address":"aws_iam_role.x","change":{"actions":["create"]}}]}`)
+		fake := &runner.Fake{CaptureOut: [][]byte{[]byte("dev\n"), planJSON}}
+		rt := &app.Runtime{
+			Target: "dev", Runner: fake,
+			Stdin: strings.NewReader(""), Stdout: &strings.Builder{}, Stderr: &strings.Builder{},
+			Clock: fixedClock(123), SkipPrompt: true,
+		}
+		err := (&ApplyCmd{Approve: true, ForbidResourceChanges: true}).Run(context.Background(), rt)
+		if err == nil {
+			t.Fatalf("expected refusal, got nil\nrecords:\n%s", fake.Output())
+		}
+		if !strings.Contains(err.Error(), "aws_iam_role.x") {
+			t.Fatalf("error should name the offending resource: %v", err)
+		}
+		for _, cmd := range fake.Commands() {
+			if len(cmd) >= 2 && cmd[0] == "terraform" && cmd[1] == "apply" {
+				t.Fatalf("must NOT run `terraform apply` when changes are present; ran %v", cmd)
+			}
+		}
+	})
+}
+
+// TestForbidResourceChanges_FlowAppliesWhenStateOnly verifies the guarded
+// apply proceeds to `terraform apply <plan>` when the plan is state-only
+// (a forget).
+func TestForbidResourceChanges_FlowAppliesWhenStateOnly(t *testing.T) {
+	withProject(t, func() {
+		writeFile(t, ".terraform-version", "1.7.5\n")
+		writeFile(t, "vars/dev/dev.tfvars", "")
+		planJSON := []byte(`{"format_version":"1.2","resource_changes":[{"address":"aws_s3_bucket.imp","change":{"actions":["forget"]}}]}`)
+		fake := &runner.Fake{CaptureOut: [][]byte{[]byte("dev\n"), planJSON}}
+		rt := &app.Runtime{
+			Target: "dev", Runner: fake,
+			Stdin: strings.NewReader(""), Stdout: &strings.Builder{}, Stderr: &strings.Builder{},
+			Clock: fixedClock(123), SkipPrompt: true,
+		}
+		err := (&ApplyCmd{Approve: true, ForbidResourceChanges: true}).Run(context.Background(), rt)
+		if err != nil {
+			t.Fatalf("state-only apply should succeed: %v\nrecords:\n%s", err, fake.Output())
+		}
+		applied := false
+		for _, cmd := range fake.Commands() {
+			if len(cmd) == 3 && cmd[0] == "terraform" && cmd[1] == "apply" && strings.Contains(cmd[2], ".tf-plans") {
+				applied = true
+			}
+		}
+		if !applied {
+			t.Fatalf("expected `terraform apply <savedplan>` for a state-only plan\nrecords:\n%s", fake.Output())
+		}
+	})
+}

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/luthersystems/mars/internal/app"
 	"github.com/luthersystems/mars/internal/runner"
 )
@@ -44,6 +46,14 @@ type ApplyCmd struct {
 	Target      string `name:"target"`
 	Approve     bool   `name:"approve"`
 	RefreshOnly bool   `name:"refresh-only"`
+	// ForbidResourceChanges makes apply fail if the plan would create,
+	// update, or delete (incl. replace) ANY managed resource. State-only
+	// operations — `no-op`, `read`, and `forget` (a `removed{ destroy =
+	// false }` block) — are allowed. Generic guard: lets a caller safely
+	// apply state-only changes (e.g. forgetting adopted resources before a
+	// destroy) and fail loudly if the same apply would also touch real
+	// infrastructure.
+	ForbidResourceChanges bool `name:"forbid-resource-changes" help:"Fail if the plan would create, update, or delete any resource; allow state-only ops (forget/no-op/read)."`
 }
 
 type DestroyCmd struct {
@@ -197,6 +207,9 @@ func (c *ApplyCmd) Run(ctx context.Context, rt *app.Runtime) error {
 	if err := s.beforeWorkspaceCommand(ctx); err != nil {
 		return err
 	}
+	if c.ForbidResourceChanges {
+		return c.runGuardedApply(ctx, s)
+	}
 	var args []string
 	if c.Plan != "" {
 		args = []string{c.Plan}
@@ -213,6 +226,110 @@ func (c *ApplyCmd) Run(ctx context.Context, rt *app.Runtime) error {
 		args = append(args, "-auto-approve")
 	}
 	return s.sequence(ctx, s.workspaceSelect(), runner.Cmd("terraform", append([]string{"apply"}, args...)...))
+}
+
+// runGuardedApply implements --forbid-resource-changes: produce (or reuse) a
+// saved plan, inspect it via `terraform show -json`, fail if it would
+// create/update/delete any resource, then apply the vetted plan. Applying the
+// saved plan guarantees we execute exactly what we inspected (no TOCTOU) and
+// needs no -auto-approve (a saved plan is already approved).
+func (c *ApplyCmd) runGuardedApply(ctx context.Context, s *service) error {
+	planPath := c.Plan
+	if planPath == "" {
+		tmp, err := s.tempPlanPath()
+		if err != nil {
+			return err
+		}
+		planPath = tmp
+		planArgs := append([]string{"terraform", "plan", "-out=" + planPath}, s.varFileArgs()...)
+		if c.Target != "" {
+			planArgs = append(planArgs, "-target", c.Target)
+		}
+		if c.RefreshOnly {
+			planArgs = append(planArgs, "-refresh-only")
+		}
+		if err := s.sequence(ctx, s.workspaceSelect(), runner.Cmd(planArgs[0], planArgs[1:]...)); err != nil {
+			return err
+		}
+	}
+
+	raw, err := s.runner.Capture(ctx, runner.Cmd("terraform", "show", "-json", planPath))
+	if err != nil {
+		return fmt.Errorf("inspect plan for resource changes: %w", err)
+	}
+	if err := assertNoResourceChanges(s.stdout, raw); err != nil {
+		return err
+	}
+	// Apply the exact plan we vetted. A saved plan applies without prompting.
+	return s.sequence(ctx, s.workspaceSelect(), runner.Cmd("terraform", "apply", planPath))
+}
+
+// tempPlanPath creates a unique plan-output path under .tf-plans, mirroring
+// PlanCmd's --apply temp-file convention.
+func (s *service) tempPlanPath() (string, error) {
+	if err := os.MkdirAll(".tf-plans", 0o755); err != nil {
+		return "", err
+	}
+	clock := s.clock
+	if clock == nil {
+		clock = realClock{}
+	}
+	file, err := os.CreateTemp(".tf-plans", fmt.Sprintf("tf-plan-guard-%s-%d-*.out", s.env, clock.Unix()))
+	if err != nil {
+		return "", err
+	}
+	name := file.Name()
+	if err := file.Close(); err != nil {
+		return "", err
+	}
+	return name, nil
+}
+
+// assertNoResourceChanges parses a `terraform show -json` plan and returns an
+// error if any resource change would create, update, or delete (incl.
+// replace) real infrastructure. State-only actions — no-op, read, and forget
+// (a `removed{ destroy = false }`) — are permitted.
+func assertNoResourceChanges(out io.Writer, planJSON []byte) error {
+	var plan tfjson.Plan
+	if err := json.Unmarshal(planJSON, &plan); err != nil {
+		return fmt.Errorf("parse plan json: %w", err)
+	}
+	var offending []string
+	forgets := 0
+	for _, rc := range plan.ResourceChanges {
+		if rc == nil || rc.Change == nil {
+			continue
+		}
+		mutates := false
+		for _, a := range rc.Change.Actions {
+			switch a {
+			case tfjson.ActionCreate, tfjson.ActionUpdate, tfjson.ActionDelete:
+				mutates = true
+			case tfjson.ActionForget:
+				forgets++
+			}
+		}
+		if mutates {
+			offending = append(offending, fmt.Sprintf("%s (%s)", rc.Address, actionsLabel(rc.Change.Actions)))
+		}
+	}
+	if len(offending) > 0 {
+		sort.Strings(offending)
+		return fmt.Errorf("--forbid-resource-changes: refusing apply — plan would change %d resource(s): %s",
+			len(offending), strings.Join(offending, ", "))
+	}
+	if out != nil {
+		fmt.Fprintf(out, "forbid-resource-changes: OK — no create/update/delete; %d state-only forget(s)\n", forgets)
+	}
+	return nil
+}
+
+func actionsLabel(actions tfjson.Actions) string {
+	parts := make([]string, 0, len(actions))
+	for _, a := range actions {
+		parts = append(parts, string(a))
+	}
+	return strings.Join(parts, "+")
 }
 
 func (c *DestroyCmd) Run(ctx context.Context, rt *app.Runtime) error {


### PR DESCRIPTION
Generic terraform safety guard, added for the InsideOut #2048 two-step destroy but not coupled to it.

## What

`mars <env> apply --forbid-resource-changes`:
1. Produces (or reuses `--plan`) a saved plan.
2. Inspects it via `terraform show -json` (parsed with `hashicorp/terraform-json`).
3. **Fails** if the plan would create, update, or delete (incl. replace) any managed resource.
4. **Allows** state-only actions — `no-op`, `read`, and `forget` (a `removed { lifecycle { destroy = false } }`).
5. Applies the exact vetted plan (no TOCTOU; a saved plan needs no `-auto-approve`).

## Why

Lets a caller safely apply *state-only* changes — e.g. forgetting adopted / reverse-imported resources from state before a `destroy` — while failing loudly if the same apply would also touch real infrastructure. It's a generic guard (no consumer-specific logic), usable by any pipeline that wants "apply, but only if nothing real would change."

First consumer: `sandbox-infrastructure-template`'s two-step `tfDestroy` (apply the `removed{}` forgets, then destroy) — reliable #2048.

## Tests

- `assertNoResourceChanges` truth table: forget/no-op/read allowed; create/update/delete/replace refused, naming the offenders; forget+delete still refused (names the delete).
- Fake-runner flow: guarded apply refuses (runs no `terraform apply`) when a resource would change; proceeds to `apply <savedplan>` for a state-only forget.
- `go build`, `go vet`, `gofmt`, full `internal/terraform` suite green.

`terraform-json` promoted from indirect to direct dep.
