### PR TITLE
fix(dockerfile): bake single converged provider versions (AWS 6.46.0 / Google 7.16.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,26 +98,57 @@ RUN cd /tmp \
   && rm "terraform_${TF_WARMUP_VERSION}_linux_${TARGETARCH}.zip" tf_SHA256SUMS
 
 # Provider versions are kept in sync with insideout-terraform-presets and the
-# sandbox-infrastructure-template .terraform.lock.hcl that runs inside this
-# image. Bump these together with those repos to keep mirror hits useful —
-# /etc/terraformrc below configures a filesystem_mirror for these exact
-# versions. Drift falls back to a slower direct registry download (see the
-# etc/terraformrc comments), it does not break init.
-ARG AWS_PROVIDER_VERSION=6.46.0
-ARG GOOGLE_PROVIDER_VERSION=6.10.0
+# sandbox-infrastructure-template .terraform.lock.hcl files that run inside this
+# image. /etc/terraformrc below configures a filesystem_mirror, but it only
+# takes the fast symlink path when the baked version EXACTLY matches the
+# consumer's lockfile pin; any unbaked version falls back to a slow direct
+# registry download (see the etc/terraformrc comments) — which does not break
+# init, but on a slow/throttled egress path *can* time out the ~300MB AWS
+# provider download ("could not query provider registry ... Client.Timeout
+# exceeded while awaiting headers") and break the deploy.
+#
+# That is exactly what happened (reliable#2141 e2e): a single baked AWS 6.46.0
+# matched NONE of the sandbox stage locks (5.48.0 / 5.100.0 / 6.15.0), so every
+# stage fell back to the registry and cloud-provision's hashicorp/aws fetch
+# timed out 100% of the time. Bake the FULL set of versions the sandbox stages
+# actually pin so the mirror hits and init never touches the registry for these.
+#
+# Sources of truth — keep aligned with these lockfile pins (a CI drift guard,
+# test/provider_versions_test.go, fails if they diverge):
+#   AWS    5.48.0  → sandbox tf/{cloud,vm,k8s}-provision
+#   AWS    5.100.0 → sandbox tf/{account-provision,account-setup}
+#   AWS    6.15.0  → sandbox tf/custom-stack-provision (presets-composed stack)
+#   Google 5.45.2  → sandbox tf/cloud-provision
+#   Google 7.16.0  → sandbox tf/custom-stack-provision
+ARG AWS_PROVIDER_VERSIONS="5.48.0 5.100.0 6.15.0"
+ARG GOOGLE_PROVIDER_VERSIONS="5.45.2 7.16.0"
 
 RUN mkdir -p ${TF_PLUGIN_CACHE_DIR} /tmp/warmup
-WORKDIR /tmp/warmup
-RUN printf '%s\n' \
-  'terraform {' \
-  '  required_providers {' \
-  "    aws         = { source = \"hashicorp/aws\",         version = \"= ${AWS_PROVIDER_VERSION}\" }" \
-  "    google      = { source = \"hashicorp/google\",      version = \"= ${GOOGLE_PROVIDER_VERSION}\" }" \
-  "    google-beta = { source = \"hashicorp/google-beta\", version = \"= ${GOOGLE_PROVIDER_VERSION}\" }" \
-  '  }' \
-  '}' \
-  > main.tf
-RUN terraform init -input=false -backend=false
+# One `terraform init` per (provider, version) into the shared plugin cache;
+# the cache accumulates every version so the runtime filesystem_mirror resolves
+# every stage's pin via symlink instead of a registry download.
+RUN set -eux; \
+  for v in ${AWS_PROVIDER_VERSIONS}; do \
+    d="/tmp/warmup/aws-$v"; mkdir -p "$d"; \
+    printf '%s\n' \
+      'terraform {' \
+      '  required_providers {' \
+      "    aws = { source = \"hashicorp/aws\", version = \"= $v\" }" \
+      '  }' \
+      '}' > "$d/main.tf"; \
+    ( cd "$d" && terraform init -input=false -backend=false ); \
+  done; \
+  for v in ${GOOGLE_PROVIDER_VERSIONS}; do \
+    d="/tmp/warmup/google-$v"; mkdir -p "$d"; \
+    printf '%s\n' \
+      'terraform {' \
+      '  required_providers {' \
+      "    google      = { source = \"hashicorp/google\",      version = \"= $v\" }" \
+      "    google-beta = { source = \"hashicorp/google-beta\", version = \"= $v\" }" \
+      '  }' \
+      '}' > "$d/main.tf"; \
+    ( cd "$d" && terraform init -input=false -backend=false ); \
+  done
 # Ensure runtime users can read the cache even when Docker copies as root.
 RUN chmod -R a+rX ${TF_PLUGIN_CACHE_DIR}
 
@@ -245,6 +276,14 @@ ENV TF_CLI_CONFIG_FILE=/etc/terraformrc
 # block in /etc/terraformrc, the cache_dir behavior is redundant and, on older
 # terraform versions, would re-introduce the copy-instead-of-symlink path for
 # providers that fall outside the mirror's include list.
+#
+# Belt-and-suspenders for any provider/version that still falls through to the
+# registry `direct{}` path (drift, or a hashicorp/* provider outside the mirror
+# include list): raise the registry client timeout from its 10s default so a
+# slow-but-progressing query over a cold customer-account NAT doesn't cancel
+# "while awaiting headers" and break init (reliable#2141). The mirror is the
+# real fix; this just stops a transient slow path from being fatal.
+ENV TF_REGISTRY_CLIENT_TIMEOUT=30
 
 COPY --from=downloader /usr/local/bin/helm /opt/bin/helm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,18 +110,19 @@ RUN cd /tmp \
 # That is exactly what happened (reliable#2141 e2e): a single baked AWS 6.46.0
 # matched NONE of the sandbox stage locks (5.48.0 / 5.100.0 / 6.15.0), so every
 # stage fell back to the registry and cloud-provision's hashicorp/aws fetch
-# timed out 100% of the time. Bake the FULL set of versions the sandbox stages
-# actually pin so the mirror hits and init never touches the registry for these.
+# timed out 100% of the time.
+#
+# sandbox-infrastructure-template#149 then converged every stage onto a single
+# modern AWS (6.46.0) and Google (7.16.0), so the mirror only needs one version
+# of each. Bake exactly those; any future stage bump must update this block and
+# re-check against the sandbox locks.
 #
 # Sources of truth — keep aligned with these lockfile pins (a CI drift guard,
-# test/provider_versions_test.go, fails if they diverge):
-#   AWS    5.48.0  → sandbox tf/{cloud,vm,k8s}-provision
-#   AWS    5.100.0 → sandbox tf/{account-provision,account-setup}
-#   AWS    6.15.0  → sandbox tf/custom-stack-provision (presets-composed stack)
-#   Google 5.45.2  → sandbox tf/cloud-provision
-#   Google 7.16.0  → sandbox tf/custom-stack-provision
-ARG AWS_PROVIDER_VERSIONS="5.48.0 5.100.0 6.15.0"
-ARG GOOGLE_PROVIDER_VERSIONS="5.45.2 7.16.0"
+# internal/providercache/providercache_test.go, fails if they diverge):
+#   AWS    6.46.0  → sandbox tf/{account-provision,account-setup,cloud-provision,vm-provision,k8s-provision,custom-stack-provision}
+#   Google 7.16.0  → sandbox tf/{cloud-provision,custom-stack-provision}
+ARG AWS_PROVIDER_VERSIONS="6.46.0"
+ARG GOOGLE_PROVIDER_VERSIONS="7.16.0"
 
 RUN mkdir -p ${TF_PLUGIN_CACHE_DIR} /tmp/warmup
 # One `terraform init` per (provider, version) into the shared plugin cache;

--- a/internal/providercache/providercache_test.go
+++ b/internal/providercache/providercache_test.go
@@ -45,6 +45,9 @@ var (
 	googleArgRe = regexp.MustCompile(`(?m)^ARG GOOGLE_PROVIDER_VERSIONS="([^"]*)"`)
 	// e.g. `#   AWS    5.48.0  → sandbox tf/{cloud,vm,k8s}-provision`
 	srcOfTruthRe = regexp.MustCompile(`(?m)^#\s+(AWS|Google)\s+(\d+\.\d+\.\d+)\b`)
+	// expect-array rows in scripts/smoke-tf-cache.sh, e.g.
+	//   "hashicorp/google-beta 7.16.0 terraform-provider-google-beta_v7.16.0_x5"
+	smokeExpectRe = regexp.MustCompile(`"hashicorp/([a-z-]+)\s+(\d+\.\d+\.\d+)\s`)
 )
 
 func argVersions(t *testing.T, body string, re *regexp.Regexp, name string) []string {
@@ -112,5 +115,69 @@ func TestBakedVersionsMatchSourcesOfTruthComment(t *testing.T) {
 		t.Errorf("Google bake vs 'Sources of truth' comment drift:\n  baked   = %v\n  comment = %v\n"+
 			"Update both together (and re-check against sandbox-infrastructure-template tf/*/.terraform.lock.hcl).",
 			google, commentGoogle)
+	}
+}
+
+// smokeScriptPath resolves scripts/smoke-tf-cache.sh relative to this test file
+// (internal/providercache/ -> ../../scripts/smoke-tf-cache.sh).
+func smokeScriptPath(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	return filepath.Join(wd, "..", "..", "scripts", "smoke-tf-cache.sh")
+}
+
+// TestSmokeExpectMatchesBakedVersions fails if the provider versions the CI
+// smoke test (scripts/smoke-tf-cache.sh) asserts are present in the image cache
+// drift from the versions the Dockerfile actually bakes. That smoke test runs
+// only after a full (~7 min) multi-arch image build, so without this same-repo
+// guard a version bump that updates the Dockerfile ARGs but not the smoke
+// script's expect array fails late and expensively — exactly what happened when
+// the bake moved to AWS 6.46.0 / Google 7.16.0 but the script still expected
+// google 6.10.0. google-beta tracks the google version.
+func TestSmokeExpectMatchesBakedVersions(t *testing.T) {
+	dockerfile, err := os.ReadFile(dockerfilePath(t))
+	if err != nil {
+		t.Fatalf("read Dockerfile: %v", err)
+	}
+	bakedAWS := sortedUnique(argVersions(t, string(dockerfile), awsArgRe, "AWS_PROVIDER_VERSIONS"))
+	bakedGoogle := sortedUnique(argVersions(t, string(dockerfile), googleArgRe, "GOOGLE_PROVIDER_VERSIONS"))
+
+	smoke, err := os.ReadFile(smokeScriptPath(t))
+	if err != nil {
+		t.Fatalf("read smoke script: %v", err)
+	}
+
+	var smokeAWS, smokeGoogle, smokeGoogleBeta []string
+	for _, m := range smokeExpectRe.FindAllStringSubmatch(string(smoke), -1) {
+		switch m[1] {
+		case "aws":
+			smokeAWS = append(smokeAWS, m[2])
+		case "google":
+			smokeGoogle = append(smokeGoogle, m[2])
+		case "google-beta":
+			smokeGoogleBeta = append(smokeGoogleBeta, m[2])
+		}
+	}
+	smokeAWS = sortedUnique(smokeAWS)
+	smokeGoogle = sortedUnique(smokeGoogle)
+	smokeGoogleBeta = sortedUnique(smokeGoogleBeta)
+
+	if len(smokeAWS) == 0 || len(smokeGoogle) == 0 || len(smokeGoogleBeta) == 0 {
+		t.Fatalf("could not parse smoke-tf-cache.sh expect array "+
+			"(aws=%v google=%v google-beta=%v); if its format changed, update smokeExpectRe",
+			smokeAWS, smokeGoogle, smokeGoogleBeta)
+	}
+
+	if strings.Join(smokeAWS, " ") != strings.Join(bakedAWS, " ") {
+		t.Errorf("smoke-tf-cache.sh AWS versions drift from the Dockerfile bake:\n  smoke = %v\n  baked = %v", smokeAWS, bakedAWS)
+	}
+	if strings.Join(smokeGoogle, " ") != strings.Join(bakedGoogle, " ") {
+		t.Errorf("smoke-tf-cache.sh google versions drift from the Dockerfile bake:\n  smoke = %v\n  baked = %v", smokeGoogle, bakedGoogle)
+	}
+	if strings.Join(smokeGoogleBeta, " ") != strings.Join(bakedGoogle, " ") {
+		t.Errorf("smoke-tf-cache.sh google-beta versions drift from the Dockerfile google bake:\n  smoke = %v\n  baked = %v", smokeGoogleBeta, bakedGoogle)
 	}
 }

--- a/internal/providercache/providercache_test.go
+++ b/internal/providercache/providercache_test.go
@@ -1,0 +1,116 @@
+// Package providercache holds a CI drift guard for the baked Terraform
+// provider cache in the mars image.
+//
+// Background (reliable#2141): the mars Dockerfile pre-bakes a filesystem mirror
+// of the AWS/Google Terraform providers at /opt/tf-plugin-cache so that
+// `terraform init` inside an Argo deploy resolves them via symlink instead of a
+// ~300MB registry download. The mirror only HITS when the baked version exactly
+// matches the version the consumer's .terraform.lock.hcl pins; a miss falls
+// back to a registry download that, over a cold customer-account NAT, timed out
+// and broke 100% of deploys. The bake had drifted to a single AWS 6.46.0 that
+// matched none of the sandbox-infrastructure-template stage locks.
+//
+// The real source of truth for which versions must be baked lives cross-repo in
+// sandbox-infrastructure-template's tf/*/.terraform.lock.hcl files, which mars
+// CI does not check out. This guard enforces the next best, same-repo
+// invariant: the human-readable "Sources of truth" comment block in the
+// Dockerfile (which names each version and the sandbox stage that pins it) must
+// stay in lockstep with the actual baked ARG defaults. So whoever bumps the
+// bake is forced to keep an accurate, reviewable map that the next operator can
+// diff against the sandbox locks — the documentation can't silently rot.
+package providercache
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// dockerfilePath resolves the repo-root Dockerfile relative to this test file
+// (internal/providercache/ -> ../../Dockerfile).
+func dockerfilePath(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	return filepath.Join(wd, "..", "..", "Dockerfile")
+}
+
+var (
+	awsArgRe    = regexp.MustCompile(`(?m)^ARG AWS_PROVIDER_VERSIONS="([^"]*)"`)
+	googleArgRe = regexp.MustCompile(`(?m)^ARG GOOGLE_PROVIDER_VERSIONS="([^"]*)"`)
+	// e.g. `#   AWS    5.48.0  → sandbox tf/{cloud,vm,k8s}-provision`
+	srcOfTruthRe = regexp.MustCompile(`(?m)^#\s+(AWS|Google)\s+(\d+\.\d+\.\d+)\b`)
+)
+
+func argVersions(t *testing.T, body string, re *regexp.Regexp, name string) []string {
+	t.Helper()
+	m := re.FindStringSubmatch(body)
+	if m == nil {
+		t.Fatalf("could not find %s ARG in Dockerfile; if it was renamed, update this guard", name)
+	}
+	return strings.Fields(m[1])
+}
+
+func sortedUnique(in []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, v := range in {
+		if !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestBakedVersionsMatchSourcesOfTruthComment fails if the Dockerfile's baked
+// AWS_PROVIDER_VERSIONS / GOOGLE_PROVIDER_VERSIONS ARGs diverge from the
+// "Sources of truth" comment block that documents which sandbox stage pins each
+// version. Keeping them aligned guarantees the comment is a trustworthy map for
+// the cross-repo check against sandbox-infrastructure-template's lockfiles.
+func TestBakedVersionsMatchSourcesOfTruthComment(t *testing.T) {
+	raw, err := os.ReadFile(dockerfilePath(t))
+	if err != nil {
+		t.Fatalf("read Dockerfile: %v", err)
+	}
+	body := string(raw)
+
+	aws := sortedUnique(argVersions(t, body, awsArgRe, "AWS_PROVIDER_VERSIONS"))
+	google := sortedUnique(argVersions(t, body, googleArgRe, "GOOGLE_PROVIDER_VERSIONS"))
+
+	if len(aws) == 0 {
+		t.Fatal("AWS_PROVIDER_VERSIONS is empty — at least one version must be baked")
+	}
+	if len(google) == 0 {
+		t.Fatal("GOOGLE_PROVIDER_VERSIONS is empty — at least one version must be baked")
+	}
+
+	var commentAWS, commentGoogle []string
+	for _, m := range srcOfTruthRe.FindAllStringSubmatch(body, -1) {
+		switch m[1] {
+		case "AWS":
+			commentAWS = append(commentAWS, m[2])
+		case "Google":
+			commentGoogle = append(commentGoogle, m[2])
+		}
+	}
+	commentAWS = sortedUnique(commentAWS)
+	commentGoogle = sortedUnique(commentGoogle)
+
+	if strings.Join(aws, " ") != strings.Join(commentAWS, " ") {
+		t.Errorf("AWS bake vs 'Sources of truth' comment drift:\n  baked   = %v\n  comment = %v\n"+
+			"Update both together (and re-check against sandbox-infrastructure-template tf/*/.terraform.lock.hcl).",
+			aws, commentAWS)
+	}
+	if strings.Join(google, " ") != strings.Join(commentGoogle, " ") {
+		t.Errorf("Google bake vs 'Sources of truth' comment drift:\n  baked   = %v\n  comment = %v\n"+
+			"Update both together (and re-check against sandbox-infrastructure-template tf/*/.terraform.lock.hcl).",
+			google, commentGoogle)
+	}
+}

--- a/scripts/smoke-tf-cache.sh
+++ b/scripts/smoke-tf-cache.sh
@@ -26,12 +26,13 @@ shopt -s nullglob
 arch=$(uname -m | sed -e s/x86_64/amd64/ -e s/aarch64/arm64/)
 
 # (provider-source, version, expected filename in the per-arch dir)
-# Keep these in sync with the AWS_PROVIDER_VERSION / GOOGLE_PROVIDER_VERSION
-# build args in the Dockerfile.
+# Keep these in sync with the AWS_PROVIDER_VERSIONS / GOOGLE_PROVIDER_VERSIONS
+# build args in the Dockerfile. Enforced at `go test` time by
+# TestSmokeExpectMatchesBakedVersions in internal/providercache/.
 expect=(
   "hashicorp/aws         6.46.0 terraform-provider-aws_v6.46.0_x5"
-  "hashicorp/google      6.10.0 terraform-provider-google_v6.10.0_x5"
-  "hashicorp/google-beta 6.10.0 terraform-provider-google-beta_v6.10.0_x5"
+  "hashicorp/google      7.16.0 terraform-provider-google_v7.16.0_x5"
+  "hashicorp/google-beta 7.16.0 terraform-provider-google-beta_v7.16.0_x5"
 )
 
 # Sanity floor on the provider binary size. AWS is ~750 MB, google ~100 MB.


### PR DESCRIPTION
## Summary

Supersedes #204. Slims the baked provider mirror to the **single** versions every sandbox stage now pins after sandbox-infrastructure-template#149:

- `AWS_PROVIDER_VERSIONS`: `5.48.0 5.100.0 6.15.0` → **`6.46.0`**
- `GOOGLE_PROVIDER_VERSIONS`: `5.45.2 7.16.0` → **`7.16.0`**

Keeps everything else #204 introduced — the warm-up loop, `TF_REGISTRY_CLIENT_TIMEOUT=30`, and the `internal/providercache` drift guard (this branch contains #204's commit plus the slim, so it's a complete replacement).

## Why this matters (merging #204 as-is would regress the fix)

#204 was written against the *old* sandbox pins. Its `AWS_PROVIDER_VERSIONS` (`5.48.0 / 5.100.0 / 6.15.0`) does **not** include `6.46.0`. The live mars image currently bakes a single AWS `6.46.0`, which is exactly why sandbox#149 works the moment it merged (stages pin 6.46.0 → mirror hit).

If #204 shipped as-is it would **replace** the 6.46.0 bake with the old 5.x set — none of which any stage pins anymore — so the converged stages would miss the mirror and fall back to the ~300MB `hashicorp/aws` registry download, reintroducing the exact timeout from #148. This PR bakes what the stages actually pin now.

| Provider | Stage pins (post-#149) | This PR bakes | Result |
|---|---|---|---|
| AWS | 6.46.0 | 6.46.0 | ✅ mirror hit |
| Google | 7.16.0 | 7.16.0 | ✅ mirror hit |

## Also

- Updated the "Sources of truth" comment map to the converged pins.
- Fixed a stale path in that comment (`test/provider_versions_test.go` → `internal/providercache/providercache_test.go`).

## Test plan

- [x] `go test ./internal/providercache/` — drift guard green (baked ARGs match the Sources-of-truth comment).
- [x] `go vet ./internal/providercache/` clean.
- [x] Warm-up loop unchanged from #204 (now iterates one version each).
- [ ] **Needs CI:** the multi-arch image build (`mars-ci.yml`); image is smaller than #204 (one provider version each instead of the full set).
- [ ] After release: bump `.mars-version` in ui-infrastructure, then a real deploy should resolve cloud-provision's `hashicorp/aws` and `hashicorp/google` via the mirror (no registry download).

## Merge order

1. ✅ sandbox-infrastructure-template#149 (merged) — converged stages to 6.46.0 / 7.16.0.
2. **This PR** → then tag a mars release + bump `.mars-version` in ui-infrastructure (makes Google fast too; AWS is already fast against today's image).
3. insideout-terraform-presets — pin composer custom-stack to 6.46.0 / 7.16.0.

Closes #204 (supersedes; please close #204 in favor of this).

Refs #148

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyG5mhtJxLgAgcqkKDjRET)_