### PR TITLE
fix(dockerfile): bake aws 6.52.0 + google 6.10.0 (community-module compatible)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,16 +113,18 @@ RUN cd /tmp \
 # timed out 100% of the time.
 #
 # sandbox-infrastructure-template#149 then converged every stage onto a single
-# modern AWS (6.46.0) and Google (7.16.0), so the mirror only needs one version
-# of each. Bake exactly those; any future stage bump must update this block and
-# re-check against the sandbox locks.
+# modern AWS (6.52.0) and Google (6.10.0), so the mirror only needs one version
+# of each. Those exact pins are bounded by the community modules the composed
+# stacks pull: terraform-aws-modules/eks 21.x floors aws >= 6.52, and
+# terraform-google-modules cap google < 7. Bake exactly those; any future stage
+# bump must update this block and re-check against the sandbox locks.
 #
 # Sources of truth — keep aligned with these lockfile pins (a CI drift guard,
 # internal/providercache/providercache_test.go, fails if they diverge):
-#   AWS    6.46.0  → sandbox tf/{account-provision,account-setup,cloud-provision,vm-provision,k8s-provision,custom-stack-provision}
-#   Google 7.16.0  → sandbox tf/{cloud-provision,custom-stack-provision}
-ARG AWS_PROVIDER_VERSIONS="6.46.0"
-ARG GOOGLE_PROVIDER_VERSIONS="7.16.0"
+#   AWS    6.52.0  → sandbox tf/{account-provision,account-setup,cloud-provision,vm-provision,k8s-provision,custom-stack-provision}
+#   Google 6.10.0  → sandbox tf/{cloud-provision,custom-stack-provision}
+ARG AWS_PROVIDER_VERSIONS="6.52.0"
+ARG GOOGLE_PROVIDER_VERSIONS="6.10.0"
 
 RUN mkdir -p ${TF_PLUGIN_CACHE_DIR} /tmp/warmup
 # One `terraform init` per (provider, version) into the shared plugin cache;

--- a/scripts/smoke-tf-cache.sh
+++ b/scripts/smoke-tf-cache.sh
@@ -30,9 +30,9 @@ arch=$(uname -m | sed -e s/x86_64/amd64/ -e s/aarch64/arm64/)
 # build args in the Dockerfile. Enforced at `go test` time by
 # TestSmokeExpectMatchesBakedVersions in internal/providercache/.
 expect=(
-  "hashicorp/aws         6.46.0 terraform-provider-aws_v6.46.0_x5"
-  "hashicorp/google      7.16.0 terraform-provider-google_v7.16.0_x5"
-  "hashicorp/google-beta 7.16.0 terraform-provider-google-beta_v7.16.0_x5"
+  "hashicorp/aws         6.52.0 terraform-provider-aws_v6.52.0_x5"
+  "hashicorp/google      6.10.0 terraform-provider-google_v6.10.0_x5"
+  "hashicorp/google-beta 6.10.0 terraform-provider-google-beta_v6.10.0_x5"
 )
 
 # Sanity floor on the provider binary size. AWS is ~750 MB, google ~100 MB.
@@ -162,7 +162,7 @@ else
   cat >main.tf <<EOF
 terraform {
   required_providers {
-    aws = { source = "hashicorp/aws", version = "= 6.46.0" }
+    aws = { source = "hashicorp/aws", version = "= 6.52.0" }
   }
 }
 EOF
@@ -181,7 +181,7 @@ EOF
     # terraform symlinks the per-arch *directory* (not each provider binary
     # individually) from the filesystem_mirror into the workdir. See
     # internal/providercache/package_install.go installFromLocalDir.
-    arch_dir="${workdir}/.terraform/providers/registry.terraform.io/hashicorp/aws/6.46.0/linux_${arch}"
+    arch_dir="${workdir}/.terraform/providers/registry.terraform.io/hashicorp/aws/6.52.0/linux_${arch}"
     if [ ! -e "${arch_dir}" ]; then
       echo "FAIL: expected provider dir not present at ${arch_dir}"
       find "${workdir}/.terraform/providers" -maxdepth 6 2>&1 || true
@@ -196,7 +196,7 @@ EOF
         /opt/tf-plugin-cache/*)
           echo "OK:   terraform init symlinked aws/linux_${arch} into workdir (-> ${target})"
           # Sanity-check the symlink resolves to the actual provider binary.
-          if [ ! -x "${arch_dir}/terraform-provider-aws_v6.46.0_x5" ]; then
+          if [ ! -x "${arch_dir}/terraform-provider-aws_v6.52.0_x5" ]; then
             echo "FAIL: symlink resolves but expected binary missing or not executable"
             fail=1
           fi ;;


### PR DESCRIPTION
## Summary

Corrects the convergence targets from #205. The composed customer stacks pull **community Terraform modules** that bound the usable provider versions — and the exact mars-mirror pins must respect those bounds:

| Provider | #205 pin | Problem | This PR |
|---|---|---|---|
| aws | `6.46.0` | `terraform-aws-modules/eks` 21.24.0 requires `>= 6.52` → composed AWS stacks fail init (`no version satisfies = 6.46.0, >= 6.52.0`) | **`6.52.0`** |
| google | `7.16.0` | `terraform-google-modules` (network/kubernetes-engine) cap `< 7` → composed GCP stacks fail init | **`6.10.0`** |

Both verified locally by reproducing the exact constraint resolution against the real upstream module `versions.tf`.

## Changes
- `AWS_PROVIDER_VERSIONS` `6.46.0` → `6.52.0`
- `GOOGLE_PROVIDER_VERSIONS` `7.16.0` → `6.10.0`
- `scripts/smoke-tf-cache.sh` expectations + symlink E2E + the sources-of-truth comment updated.
- `internal/providercache` drift guards green (`go test ./internal/providercache/`).

## Test plan
- [x] `go test ./internal/providercache/` (drift guard + smoke-vs-Dockerfile guard).
- [x] `bash -n scripts/smoke-tf-cache.sh`; binary filenames confirmed (`_x5` for all three).
- [ ] mars-ci image build + smoke (runs on this PR).

## Pairs with
- sandbox-infrastructure-template: stage locks → aws 6.52.0 / google 6.10.0.
- insideout-terraform-presets: composer `baseProviderPins` aws → 6.52.0 (google already 6.10.0).

Refs #148

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyG5mhtJxLgAgcqkKDjRET)_