### PR TITLE
fix(reverse-import): treat partial status as a usable success (exit 0)

### DIFF
--- a/internal/reverseimportjob/job.go
+++ b/internal/reverseimportjob/job.go
@@ -246,13 +246,46 @@ func Main(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer
 		}
 		return 1
 	}
-	if result.Status != "" && result.Status != reversejob.StatusSucceeded {
+	// A PARTIAL result is the partial-tolerant engine's designed-for outcome on a
+	// whole-account import (presets#732/#734): reverseimport.Run imported every
+	// plannable resource and ISOLATED the genuinely-unimportable ones — terraform
+	// `generate-config-out` produced no resource body, an unsupported type, or a
+	// first-import contract drop — into result.Resources with per-resource
+	// diagnostics. That is a USABLE import: the stack state carries every imported
+	// resource and the caller (ui-core → reliable → the import wizard) surfaces the
+	// skipped/failed set from result.json. Failing the whole job on it defeats the
+	// entire partial-tolerant engine.
+	//
+	// Before this, mars exited 1 on ANY non-succeeded status, so a whole-account
+	// import FAILED whenever a single resource could not be generated. Triggering
+	// case: account 141812438321 (staging session sess_v2_fvZSf5IfhLCb) imported
+	// 361 resources cleanly but 2 orphans (an IAM role + a KMS key whose
+	// generate-config-out produced no body) were skipped → status "partial" → mars
+	// returned 1 → JOB_STATUS_FAILURE, even though the import was fine. See
+	// reliable tf_start.go ReverseImportMarsVersion history (#835 publish-fix sweep).
+	//
+	// Only a hard failure (StatusFailed: zero imported / systemic) or an unknown
+	// non-success status remains fatal. An empty status keeps the prior lenient
+	// (success) behavior.
+	switch result.Status {
+	case "", reversejob.StatusSucceeded, reversejob.StatusPartial:
+		// usable result — fall through to the success summary below
+	default:
 		err := fmt.Errorf("reverse import ended with status %q", result.Status)
 		fmt.Fprintf(stderr, "insideout-reverse-import: %v\n", err)
 		if writeErr := ensureFailureResult(cfg.outputDir, result, err); writeErr != nil {
 			fmt.Fprintf(stderr, "insideout-reverse-import: write failure result: %v\n", writeErr)
 		}
 		return 1
+	}
+
+	if result.Status == reversejob.StatusPartial {
+		fmt.Fprintf(stdout, "reverse import completed (partial): %d imported, %d add, %d change, %d destroy — some resources were skipped/failed and isolated; see result.json for per-resource diagnostics\n",
+			result.PlanSummary.ImportCount,
+			result.PlanSummary.AddCount,
+			result.PlanSummary.ChangeCount,
+			result.PlanSummary.DestroyCount)
+		return 0
 	}
 
 	fmt.Fprintf(stdout, "reverse import succeeded: %d imported, %d add, %d change, %d destroy\n",

--- a/internal/reverseimportjob/job_test.go
+++ b/internal/reverseimportjob/job_test.go
@@ -698,6 +698,61 @@ func TestMainWritesFailureResultWhenSDKReturnsFailedStatus(t *testing.T) {
 	}
 }
 
+// TestMainTreatsPartialStatusAsSuccess pins the whole-account-import fix: the
+// partial-tolerant engine (presets#732/#734) returns StatusPartial when it
+// imported every plannable resource and isolated the genuinely-unimportable
+// ones. mars must treat that as a USABLE success (exit 0) — not fail the whole
+// job — so a whole-account import with a couple of unimportable orphans still
+// lands the rest. Regression target: account 141812438321 (361 imported, 2
+// orphan-skipped → partial) used to exit 1 → JOB_STATUS_FAILURE.
+func TestMainTreatsPartialStatusAsSuccess(t *testing.T) {
+	useFakeDiscoverer(t)
+	dir := t.TempDir()
+	requestPath := filepath.Join(dir, "request.json")
+	outputDir := filepath.Join(dir, "out")
+	writeRequest(t, requestPath)
+
+	const partialResult = `{"version":1,"status":"partial","resources":[{"status":"skipped"}]}`
+	run := func(_ context.Context, _ reversejob.Request, opts reverseimport.Options) (reversejob.Result, error) {
+		if err := os.MkdirAll(opts.OutputDir, 0o755); err != nil {
+			return reversejob.Result{}, err
+		}
+		// The engine writes result.json itself on the non-failure path; emulate
+		// that so we can assert mars does NOT clobber it via ensureFailureResult.
+		if err := os.WriteFile(filepath.Join(opts.OutputDir, resultFile), []byte(partialResult), 0o644); err != nil {
+			return reversejob.Result{}, err
+		}
+		return reversejob.Result{
+			Version:     reversejob.Version,
+			Status:      reversejob.StatusPartial,
+			PlanSummary: reversejob.PlanSummary{ImportCount: 361},
+		}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Main(context.Background(), []string{"--request", requestPath, "--out-dir", outputDir}, &stdout, &stderr, run)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (partial is a usable success); stderr:\n%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "partial") || !strings.Contains(stdout.String(), "361 imported") {
+		t.Fatalf("stdout = %q, want a partial success summary mentioning the import count", stdout.String())
+	}
+	// The partial result.json the engine wrote must survive — mars must not
+	// rewrite it as a failure result.
+	raw, err := os.ReadFile(filepath.Join(outputDir, resultFile))
+	if err != nil {
+		t.Fatalf("read result: %v", err)
+	}
+	var result reversejob.Result
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("decode result: %v\n%s", err, raw)
+	}
+	if result.Status != reversejob.StatusPartial {
+		t.Fatalf("status = %q, want %q (mars must not overwrite a partial result)", result.Status, reversejob.StatusPartial)
+	}
+}
+
 func TestMainRejectsInsideOutImportedMarkerBeforePlan(t *testing.T) {
 	useFakeDiscoverer(t)
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

The reverse-import job binary (`internal/reverseimportjob/job.go`) exited `1` on **any** non-`succeeded` status — including `partial`. That defeats the partial-tolerant engine (presets#732/#734), whose whole purpose is to import every plannable resource and *isolate* the genuinely-unimportable ones.

`partial` is a **usable** import: the stack state carries every imported resource, and the skipped/failed set is reported in `result.json` with per-resource diagnostics for the caller (ui-core → reliable → the import wizard) to surface. Failing the whole job on it throws away a good import.

## Triggering case

Whole-account reverse-import of account `141812438321` (staging session `sess_v2_fvZSf5IfhLCb`, job `ri-897a6c4e-gq8xt`): **361 resources imported cleanly**, but 2 orphans (an IAM role + a KMS key whose `terraform plan -generate-config-out` produced no resource body) were skipped → status `partial` → mars returned `1` → `JOB_STATUS_FAILURE`, even though the import was fine.

## Change

`job.go`: only a hard failure (`StatusFailed` — zero imported / systemic) or an unknown non-success status stays fatal. `StatusSucceeded`, `StatusPartial`, and empty status return `0`. Partial prints a distinct summary and the engine-written `result.json` (status `partial` + diagnostics) is preserved (not overwritten by `ensureFailureResult`).

Adds `TestMainTreatsPartialStatusAsSuccess`.

## Rollout

This is one half of the whole-account-import fix. The other half (the `publish` first-import-contract forgiveness, presets#835) already shipped in mars v0.126.0. Cutting **v0.127.0** from this gives a single image with both; reliable's `ReverseImportMarsVersion` and ui-core's `marsVersion` then pin v0.127.0.

## Test plan

- `go build ./...` OK
- `go test ./internal/reverseimportjob/...` OK (incl. new partial test; `failed`/unknown still exit non-zero)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9mZGiqtkryFohgBP5SUFR)_