### PR TITLE
Add insideout-preflight binary: Go port of the bootstrap permission preflights (reliable#2243)

### DIFF
--- a/.github/workflows/mars-ci.yml
+++ b/.github/workflows/mars-ci.yml
@@ -29,3 +29,7 @@ jobs:
         if: matrix.image == 'mars'
         shell: bash
         run: ./scripts/smoke-tf-cache.sh "luthersystems/mars:${GITHUB_SHA}"
+      - name: Verify insideout-preflight binary
+        if: matrix.image == 'mars'
+        shell: bash
+        run: ./scripts/smoke-preflight.sh "luthersystems/mars:${GITHUB_SHA}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -167,6 +167,7 @@ RUN mkdir -p /out && \
   CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w -X github.com/luthersystems/mars/internal/cli.Version=${MARS_VERSION}" -o /out/mars ./cmd/mars && \
   CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o /out/mars-entrypoint ./cmd/mars-entrypoint && \
   CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o /out/insideout-reverse-import ./cmd/insideout-reverse-import && \
+  CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o /out/insideout-preflight ./cmd/insideout-preflight && \
   CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o /out/vault-aws-secretsmanager ./cmd/vault-aws-secretsmanager && \
   CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o /out/vault-az-keyvault ./cmd/vault-az-keyvault
 
@@ -208,6 +209,7 @@ COPY --from=downloader /tmp/tfmigrate /opt/bin/tfmigrate
 COPY --from=mars-cli /out/mars /opt/bin/mars
 COPY --from=mars-cli /out/mars-entrypoint /opt/bin/mars-entrypoint
 COPY --from=mars-cli /out/insideout-reverse-import /opt/bin/insideout-reverse-import
+COPY --from=mars-cli /out/insideout-preflight /opt/bin/insideout-preflight
 COPY --from=mars-cli /out/vault-aws-secretsmanager /opt/bin/vault-aws-secretsmanager
 COPY --from=mars-cli /out/vault-az-keyvault /opt/bin/vault-az-keyvault
 COPY --from=downloader /tmp/awscliv2.zip /tmp/awscliv2.zip
@@ -221,6 +223,7 @@ RUN chmod a+x /opt/bin/mars /opt/bin/mars-entrypoint /opt/bin/vault-aws-secretsm
   ln -sf /opt/bin/vault-aws-secretsmanager /opt/mars/vault-aws-secretsmanager && \
   ln -sf /opt/bin/vault-az-keyvault /opt/mars/vault-az-keyvault
 RUN chmod a+x /opt/bin/insideout-reverse-import && ln -sf /opt/bin/insideout-reverse-import /usr/local/bin/insideout-reverse-import
+RUN chmod a+x /opt/bin/insideout-preflight && ln -sf /opt/bin/insideout-preflight /usr/local/bin/insideout-preflight
 
 COPY ssh_config /etc/ssh/ssh_config
 # Grab bitbucket.org keys and place in known_hosts

--- a/cmd/insideout-preflight/main.go
+++ b/cmd/insideout-preflight/main.go
@@ -1,0 +1,27 @@
+// Command insideout-preflight runs fail-fast bootstrap-permission preflights
+// for InsideOut cloud deploys (luthersystems/reliable#2243).
+//
+// It is the Go port of the sandbox-infrastructure-template shell preflights
+// (tf/gcp-preflight.sh, tf/aws-preflight.sh). The template keeps the hook, the
+// SKIP_*_BOOTSTRAP_PREFLIGHT escape hatches, and the permission/action lists;
+// this binary takes those lists as INPUT and supplies the mechanics with typed
+// SDK error classification.
+//
+// See package github.com/luthersystems/mars/internal/preflight for the full CLI
+// contract (flags, exit codes, and output markers).
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+
+	"github.com/luthersystems/mars/internal/preflight"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	os.Exit(preflight.Main(ctx, os.Args[1:], os.Stdout, os.Stderr))
+}

--- a/go.mod
+++ b/go.mod
@@ -10,12 +10,16 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.12
+	github.com/aws/aws-sdk-go-v2/service/iam v1.53.10
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1
+	github.com/aws/smithy-go v1.27.0
 	github.com/hashicorp/terraform-json v0.27.2
 	github.com/joho/godotenv v1.5.1
 	github.com/luthersystems/insideout-terraform-presets v0.11.1-0.20260711215456-6640d36686f5
 	github.com/sosedoff/ansible-vault-go v0.2.0
+	golang.org/x/oauth2 v0.36.0
+	google.golang.org/api v0.278.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -53,7 +57,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.299.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/eks v1.83.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/iam v1.53.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.23 // indirect
@@ -72,7 +75,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.5 // indirect
-	github.com/aws/smithy-go v1.27.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -101,13 +103,11 @@ require (
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
-	google.golang.org/api v0.278.0 // indirect
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4 // indirect

--- a/internal/preflight/aws.go
+++ b/internal/preflight/aws.go
@@ -1,0 +1,288 @@
+package preflight
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	smithy "github.com/aws/smithy-go"
+)
+
+// stsAPI is the minimal STS surface the preflight needs. Small,
+// package-owned interfaces let tests inject fakes without a live account.
+type stsAPI interface {
+	AssumeRole(ctx context.Context, in *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error)
+	GetCallerIdentity(ctx context.Context, in *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+}
+
+// iamAPI is the minimal IAM surface. Its single method matches
+// iam.SimulatePrincipalPolicyAPIClient, so a value of this type can drive the
+// SDK paginator directly.
+type iamAPI interface {
+	SimulatePrincipalPolicy(ctx context.Context, in *iam.SimulatePrincipalPolicyInput, optFns ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error)
+}
+
+// awsSessionCreds carries assumed-role session credentials. A nil pointer means
+// "use ambient credentials".
+type awsSessionCreds struct {
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
+}
+
+// newAWSClients builds an STS + IAM client pair for the region. creds==nil uses
+// ambient credentials (LoadDefaultConfig); a non-nil creds pins static
+// assumed-role session credentials. Package var so tests can inject fakes.
+var newAWSClients = defaultAWSClients
+
+func defaultAWSClients(ctx context.Context, region string, creds *awsSessionCreds) (stsAPI, iamAPI, error) {
+	opts := []func(*config.LoadOptions) error{config.WithRegion(region)}
+	if creds != nil {
+		opts = append(opts, config.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken)))
+	}
+	cfg, err := config.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return sts.NewFromConfig(cfg), iam.NewFromConfig(cfg), nil
+}
+
+// ARN shapes for caller-identity → policy-source resolution. Partitions cover
+// aws, aws-us-gov and aws-cn (the `[a-z-]+` partition token).
+var (
+	assumedRoleARNRe = regexp.MustCompile(`^arn:([a-z-]+):sts::([0-9]+):assumed-role/([^/]+)/`)
+	iamIdentityARNRe = regexp.MustCompile(`^arn:[a-z-]+:iam::[0-9]+:(?:user|role)/`)
+)
+
+// mapCallerARNToPolicySource maps a caller identity ARN to the IAM identity ARN
+// iam:SimulatePrincipalPolicy requires. An assumed-role SESSION ARN is rewritten
+// to its role IDENTITY ARN; an IAM user/role identity ARN passes through. A
+// federated-user or root ARN (or anything unrecognized) returns ok=false, which
+// the caller treats as fail-open.
+func mapCallerARNToPolicySource(arn string) (string, bool) {
+	if m := assumedRoleARNRe.FindStringSubmatch(arn); m != nil {
+		return fmt.Sprintf("arn:%s:iam::%s:role/%s", m[1], m[2], m[3]), true
+	}
+	if iamIdentityARNRe.MatchString(arn) {
+		return arn, true
+	}
+	return "", false
+}
+
+// runAWS parses the aws subcommand flags and runs the AWS bootstrap-permission
+// preflight, returning the process exit code.
+func runAWS(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	l := logger{prefix: awsPrefix, out: stdout, err: stderr}
+
+	fs := flag.NewFlagSet("insideout-preflight aws", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		roleARN    = fs.String("role-arn", "", "customer bootstrap role ARN to assume and evaluate (empty ⇒ ambient caller identity)")
+		externalID = fs.String("external-id", "", "external id for the assume-role (confused-deputy protection)")
+		region     = fs.String("region", "us-east-1", "AWS region for the STS/IAM control-plane calls")
+		timeout    = fs.Duration("timeout", 30*time.Second, "per-call timeout")
+		actions    stringList
+	)
+	fs.Var(&actions, "actions", "required bootstrap IAM actions (comma-separated and/or repeatable)")
+	if code, ok := parseFlags(fs, args); !ok {
+		return code
+	}
+
+	if len(actions) == 0 {
+		fprintln(stderr, "insideout-preflight aws: --actions must not be empty")
+		return exitUsage
+	}
+	reg := strings.TrimSpace(*region)
+	if reg == "" {
+		reg = "us-east-1"
+	}
+
+	if strings.TrimSpace(*roleARN) != "" {
+		return l.runAWSRoleMode(ctx, *roleARN, *externalID, reg, *timeout, actions)
+	}
+	return l.runAWSAmbientMode(ctx, reg, *timeout, actions)
+}
+
+// runAWSRoleMode assumes the customer bootstrap role, then simulates the actions
+// under the assumed-role session credentials.
+func (l logger) runAWSRoleMode(ctx context.Context, roleARN, externalID, region string, timeout time.Duration, actions []string) int {
+	extNote := ""
+	if externalID != "" {
+		extNote = " +external-id"
+	}
+	l.outln(fmt.Sprintf("checking bootstrap actions against role %s (assume-role%s)", roleARN, extNote))
+
+	stsClient, _, err := newAWSClients(ctx, region, nil)
+	if err != nil {
+		return l.failOpen("could not initialize AWS clients (transient): "+err.Error(), skipAWS)
+	}
+
+	assumeCtx, cancel := context.WithTimeout(ctx, timeout)
+	in := &sts.AssumeRoleInput{
+		RoleArn:         aws.String(roleARN),
+		RoleSessionName: aws.String("insideout-bootstrap-preflight"),
+		DurationSeconds: aws.Int32(900),
+	}
+	if externalID != "" {
+		in.ExternalId = aws.String(externalID)
+	}
+	out, err := stsClient.AssumeRole(assumeCtx, in)
+	cancel()
+	if err != nil {
+		return l.classifyAssumeFailure(roleARN, err)
+	}
+	if out == nil || out.Credentials == nil ||
+		aws.ToString(out.Credentials.AccessKeyId) == "" ||
+		aws.ToString(out.Credentials.SecretAccessKey) == "" ||
+		aws.ToString(out.Credentials.SessionToken) == "" {
+		return l.failOpen(fmt.Sprintf("assume-role for %s returned an incomplete credential set (treating as infra/transient).", roleARN), skipAWS)
+	}
+
+	creds := &awsSessionCreds{
+		AccessKeyID:     aws.ToString(out.Credentials.AccessKeyId),
+		SecretAccessKey: aws.ToString(out.Credentials.SecretAccessKey),
+		SessionToken:    aws.ToString(out.Credentials.SessionToken),
+	}
+	_, iamClient, err := newAWSClients(ctx, region, creds)
+	if err != nil {
+		return l.failOpen("could not initialize IAM client under the assumed role (transient): "+err.Error(), skipAWS)
+	}
+	// SimulatePrincipalPolicy takes the role's stable identity ARN — which the
+	// caller-supplied bootstrap role ARN already is.
+	return l.simulateAndReport(ctx, iamClient, roleARN, actions, timeout)
+}
+
+// runAWSAmbientMode resolves the ambient caller identity and simulates the
+// actions against it.
+func (l logger) runAWSAmbientMode(ctx context.Context, region string, timeout time.Duration, actions []string) int {
+	stsClient, iamClient, err := newAWSClients(ctx, region, nil)
+	if err != nil {
+		return l.failOpen("could not initialize AWS clients (transient): "+err.Error(), skipAWS)
+	}
+
+	idCtx, cancel := context.WithTimeout(ctx, timeout)
+	id, err := stsClient.GetCallerIdentity(idCtx, &sts.GetCallerIdentityInput{})
+	cancel()
+	if err != nil {
+		return l.failOpen("sts:GetCallerIdentity failed (no usable ambient credentials / transient): "+err.Error(), skipAWS)
+	}
+	callerARN := aws.ToString(id.Arn)
+	policySource, ok := mapCallerARNToPolicySource(callerARN)
+	if !ok {
+		return l.failOpen(fmt.Sprintf("caller identity %s is not an IAM user/role (federated/root?) — cannot resolve a simulate policy source.", callerARN), skipAWS)
+	}
+	l.outln("checking bootstrap actions against ambient caller identity " + policySource)
+	return l.simulateAndReport(ctx, iamClient, policySource, actions, timeout)
+}
+
+// classifyAssumeFailure decides fail-closed vs fail-open for a failed
+// sts:AssumeRole. An explicit AccessDenied (typed smithy.APIError code) is a
+// trust-policy / external-id problem that WILL fail the deploy → fail-closed
+// with a distinct, actionable message. Everything else (throttle, 5xx, network,
+// expired ambient creds) is not evidence of insufficiency → fail-open.
+func (l logger) classifyAssumeFailure(roleARN string, err error) int {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) && apiErr.ErrorCode() == "AccessDenied" {
+		return l.awsFailAssumeDenied(roleARN, err.Error())
+	}
+	return l.failOpen(fmt.Sprintf("could not assume bootstrap role %s (transient — throttling/5xx/network/expired creds): %s", roleARN, err.Error()), skipAWS)
+}
+
+// simulateAndReport runs iam:SimulatePrincipalPolicy (paginated) for the actions
+// and reports the verdict. ANY simulate error is fail-open (inability to verify
+// is not proof of insufficiency); only a successful simulate that leaves a
+// required action non-"allowed" is fail-closed.
+func (l logger) simulateAndReport(ctx context.Context, iamClient iamAPI, policySource string, actions []string, timeout time.Duration) int {
+	simCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	pag := iam.NewSimulatePrincipalPolicyPaginator(iamClient, &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: aws.String(policySource),
+		ActionNames:     actions,
+	})
+	allowed := make(map[string]bool, len(actions))
+	for pag.HasMorePages() {
+		page, err := pag.NextPage(simCtx)
+		if err != nil {
+			return l.failOpen("iam:SimulatePrincipalPolicy call failed (cannot verify — the principal may lack iam:SimulatePrincipalPolicy, or a transient AWS error): "+err.Error(), skipAWS)
+		}
+		for _, ev := range page.EvaluationResults {
+			// Only an exact "allowed" decision counts; explicitDeny / implicitDeny
+			// / anything else is treated as denied.
+			if string(ev.EvalDecision) == "allowed" {
+				allowed[aws.ToString(ev.EvalActionName)] = true
+			}
+		}
+	}
+
+	var denied []string
+	for _, a := range actions {
+		if !allowed[a] {
+			denied = append(denied, a)
+		}
+	}
+	if len(denied) == 0 {
+		l.outln(fmt.Sprintf("OK — principal %s is allowed all %d bootstrap actions.", policySource, len(actions)))
+		return exitOK
+	}
+	return l.awsFailMissing(policySource, denied, len(actions))
+}
+
+// awsFailAssumeDenied prints the assume-role AccessDenied verdict (fail-closed,
+// exit 1) — a trust-policy / external-id problem, distinct from a missing-action
+// verdict. Matches tf/aws-preflight.sh byte-for-byte.
+func (l logger) awsFailAssumeDenied(roleARN, detail string) int {
+	l.errln("")
+	l.errln("================================================================")
+	l.errln("AWS BOOTSTRAP PREFLIGHT FAILED — could not assume bootstrap role")
+	l.errln(fmt.Sprintf("%s: the assume-role call was explicitly DENIED (AccessDenied).", roleARN))
+	l.errln("")
+	l.errln("This is a TRUST-POLICY or EXTERNAL-ID problem, not a missing deploy")
+	l.errln("permission. Fix on the customer side:")
+	l.errln("  - the role's trust policy must allow the connecting deployer principal")
+	l.errln("    to sts:AssumeRole it, and")
+	l.errln("  - the external id must match the one configured for this deployment")
+	l.errln("    (aws_external_id).")
+	if strings.TrimSpace(detail) != "" {
+		l.errln(detail)
+	}
+	l.errln("")
+	l.errln("Escape hatch: set SKIP_AWS_BOOTSTRAP_PREFLIGHT=1 to bypass this check.")
+	l.errln("Ref: luthersystems/reliable#2243.")
+	l.errln("================================================================")
+	return exitFail
+}
+
+// awsFailMissing prints the definitive denied-action verdict (fail-closed, exit
+// 1). totalActions is the full required-action count for the remediation line.
+// Matches tf/aws-preflight.sh byte-for-byte.
+func (l logger) awsFailMissing(policySource string, denied []string, totalActions int) int {
+	l.errln("")
+	l.errln("================================================================")
+	l.errln("AWS BOOTSTRAP PREFLIGHT FAILED — the principal")
+	l.errln(fmt.Sprintf("%s is missing %d required IAM action(s):", policySource, len(denied)))
+	for _, action := range denied {
+		l.errln("  - " + action)
+	}
+	l.errln("")
+	l.errln("Attach the AdministratorAccess managed policy to this principal, or a")
+	l.errln(fmt.Sprintf("policy granting at minimum the %d bootstrap actions the", totalActions))
+	l.errln("cloud-provision stage needs (the denied ones are listed above), then re-run")
+	l.errln("the deploy.")
+	l.errln("")
+	l.errln("Escape hatch: set SKIP_AWS_BOOTSTRAP_PREFLIGHT=1 to bypass this check.")
+	l.errln("Ref: luthersystems/reliable#2243.")
+	l.errln("================================================================")
+	return exitFail
+}

--- a/internal/preflight/aws_test.go
+++ b/internal/preflight/aws_test.go
@@ -1,0 +1,315 @@
+package preflight
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
+	smithy "github.com/aws/smithy-go"
+)
+
+// --- fakes ------------------------------------------------------------------
+
+type fakeSTS struct {
+	assumeOut   *sts.AssumeRoleOutput
+	assumeErr   error
+	callerOut   *sts.GetCallerIdentityOutput
+	callerErr   error
+	assumeCalls int
+	callerCalls int
+}
+
+func (f *fakeSTS) AssumeRole(_ context.Context, _ *sts.AssumeRoleInput, _ ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+	f.assumeCalls++
+	return f.assumeOut, f.assumeErr
+}
+
+func (f *fakeSTS) GetCallerIdentity(_ context.Context, _ *sts.GetCallerIdentityInput, _ ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	f.callerCalls++
+	return f.callerOut, f.callerErr
+}
+
+type fakeIAM struct {
+	pages []*iam.SimulatePrincipalPolicyOutput // returned in order, one per call
+	err   error
+	calls int
+}
+
+func (f *fakeIAM) SimulatePrincipalPolicy(_ context.Context, _ *iam.SimulatePrincipalPolicyInput, _ ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	idx := f.calls
+	f.calls++
+	if idx >= len(f.pages) {
+		return &iam.SimulatePrincipalPolicyOutput{}, nil
+	}
+	return f.pages[idx], nil
+}
+
+// withFakeAWSClients installs fakes for the duration of the test.
+func withFakeAWSClients(t *testing.T, s *fakeSTS, i *fakeIAM) {
+	t.Helper()
+	orig := newAWSClients
+	newAWSClients = func(_ context.Context, _ string, _ *awsSessionCreds) (stsAPI, iamAPI, error) {
+		return s, i, nil
+	}
+	t.Cleanup(func() { newAWSClients = orig })
+}
+
+// evalPage builds one SimulatePrincipalPolicy page: each action in allowed is
+// marked "allowed"; every other action passed is marked implicitDeny. marker,
+// when non-empty, sets the pagination Marker so the paginator fetches again.
+func evalPage(marker string, actions []string, allowed ...string) *iam.SimulatePrincipalPolicyOutput {
+	allow := map[string]bool{}
+	for _, a := range allowed {
+		allow[a] = true
+	}
+	var results []iamtypes.EvaluationResult
+	for _, a := range actions {
+		decision := "implicitDeny"
+		if allow[a] {
+			decision = "allowed"
+		}
+		results = append(results, iamtypes.EvaluationResult{
+			EvalActionName: aws.String(a),
+			EvalDecision:   iamtypes.PolicyEvaluationDecisionType(decision),
+		})
+	}
+	out := &iam.SimulatePrincipalPolicyOutput{EvaluationResults: results}
+	if marker != "" {
+		out.IsTruncated = true
+		out.Marker = aws.String(marker)
+	}
+	return out
+}
+
+func assumeCreds() *sts.AssumeRoleOutput {
+	return &sts.AssumeRoleOutput{
+		Credentials: &ststypes.Credentials{
+			AccessKeyId:     aws.String("AKIA_TEST"),
+			SecretAccessKey: aws.String("secret"),
+			SessionToken:    aws.String("token"),
+		},
+	}
+}
+
+func apiErr(code string) error {
+	return &smithy.GenericAPIError{Code: code, Message: code + " message"}
+}
+
+const testRole = "arn:aws:iam::123456789012:role/insideout-bootstrap"
+
+// --- tests ------------------------------------------------------------------
+
+func TestAWS_AllActionsAllowed_RoleMode(t *testing.T) {
+	actions := []string{"s3:CreateBucket", "iam:CreateRole", "sts:AssumeRole"}
+	withFakeAWSClients(t,
+		&fakeSTS{assumeOut: assumeCreds()},
+		&fakeIAM{pages: []*iam.SimulatePrincipalPolicyOutput{evalPage("", actions, actions...)}},
+	)
+	code, out, _ := runPreflight(t, "aws", "--role-arn", testRole, "--actions", strings.Join(actions, ","))
+	if code != exitOK {
+		t.Fatalf("exit = %d, want %d", code, exitOK)
+	}
+	if !strings.Contains(out, "OK — principal") || !strings.Contains(out, "allowed all 3 bootstrap actions") {
+		t.Errorf("missing OK summary; stdout=%q", out)
+	}
+}
+
+func TestAWS_ImplicitDenySubset_FailClosed(t *testing.T) {
+	actions := []string{"s3:CreateBucket", "iam:CreateRole", "sts:AssumeRole"}
+	// Everything allowed except the two representative create actions.
+	withFakeAWSClients(t,
+		&fakeSTS{assumeOut: assumeCreds()},
+		&fakeIAM{pages: []*iam.SimulatePrincipalPolicyOutput{evalPage("", actions, "sts:AssumeRole")}},
+	)
+	code, _, errOut := runPreflight(t, "aws", "--role-arn", testRole, "--actions", strings.Join(actions, ","))
+	if code != exitFail {
+		t.Fatalf("exit = %d, want %d", code, exitFail)
+	}
+	for _, want := range []string{
+		"AWS BOOTSTRAP PREFLIGHT FAILED — the principal",
+		"s3:CreateBucket",
+		"iam:CreateRole",
+		"AdministratorAccess",
+		"reliable#2243",
+	} {
+		if !strings.Contains(errOut, want) {
+			t.Errorf("stderr missing %q; got:\n%s", want, errOut)
+		}
+	}
+	if got := countPrefixLines(errOut, awsPrefix+"  - "); got != 2 {
+		t.Errorf("denied listing lines = %d, want 2; stderr=\n%s", got, errOut)
+	}
+	// The granted action must NOT surface as denied.
+	if strings.Contains(errOut, awsPrefix+"  - sts:AssumeRole") {
+		t.Errorf("granted action sts:AssumeRole must not appear in the denied listing")
+	}
+}
+
+func TestAWS_SimulateAccessDenied_FailOpen(t *testing.T) {
+	actions := []string{"s3:CreateBucket"}
+	withFakeAWSClients(t,
+		&fakeSTS{assumeOut: assumeCreds()},
+		&fakeIAM{err: apiErr("AccessDenied")}, // AccessDenied on iam:SimulatePrincipalPolicy itself
+	)
+	code, _, errOut := runPreflight(t, "aws", "--role-arn", testRole, "--actions", strings.Join(actions, ","))
+	if code != exitOK {
+		t.Fatalf("exit = %d, want %d (fail-open)", code, exitOK)
+	}
+	if !strings.Contains(errOut, "WARNING") || !strings.Contains(errOut, "SimulatePrincipalPolicy call failed") {
+		t.Errorf("stderr missing fail-open warning; got:\n%s", errOut)
+	}
+}
+
+func TestAWS_AssumeRoleAccessDenied_FailClosedDistinct(t *testing.T) {
+	withFakeAWSClients(t,
+		&fakeSTS{assumeErr: apiErr("AccessDenied")},
+		&fakeIAM{},
+	)
+	code, _, errOut := runPreflight(t, "aws", "--role-arn", testRole, "--external-id", "xid", "--actions", "s3:CreateBucket")
+	if code != exitFail {
+		t.Fatalf("exit = %d, want %d", code, exitFail)
+	}
+	if !strings.Contains(errOut, "could not assume bootstrap role") || !strings.Contains(errOut, "TRUST-POLICY") {
+		t.Errorf("stderr missing distinct assume-denied message; got:\n%s", errOut)
+	}
+	// Must NOT be conflated with the missing-action verdict.
+	if strings.Contains(errOut, "required IAM action") {
+		t.Errorf("assume-denied must not be reported as a missing-action verdict; got:\n%s", errOut)
+	}
+}
+
+func TestAWS_AssumeRoleThrottle_FailOpen(t *testing.T) {
+	withFakeAWSClients(t,
+		&fakeSTS{assumeErr: apiErr("Throttling")},
+		&fakeIAM{},
+	)
+	code, _, errOut := runPreflight(t, "aws", "--role-arn", testRole, "--actions", "s3:CreateBucket")
+	if code != exitOK {
+		t.Fatalf("exit = %d, want %d (fail-open)", code, exitOK)
+	}
+	if !strings.Contains(errOut, "WARNING") || !strings.Contains(errOut, "transient") {
+		t.Errorf("stderr missing transient fail-open warning; got:\n%s", errOut)
+	}
+}
+
+func TestAWS_PaginationMergesTwoPages(t *testing.T) {
+	actions := []string{"a1", "a2", "a3", "a4", "a5"}
+	iamC := &fakeIAM{pages: []*iam.SimulatePrincipalPolicyOutput{
+		evalPage("page2", actions, "a1", "a2"),  // page 1: a1,a2 allowed, Marker set
+		evalPage("", actions, "a3", "a4", "a5"), // page 2: a3,a4,a5 allowed, no Marker
+	}}
+	withFakeAWSClients(t, &fakeSTS{assumeOut: assumeCreds()}, iamC)
+	code, out, errOut := runPreflight(t, "aws", "--role-arn", testRole, "--actions", strings.Join(actions, ","))
+	if code != exitOK {
+		t.Fatalf("exit = %d, want %d; stderr=\n%s", code, exitOK, errOut)
+	}
+	if iamC.calls != 2 {
+		t.Errorf("simulate calls = %d, want 2 (paginator must fetch both pages)", iamC.calls)
+	}
+	if !strings.Contains(out, "allowed all 5 bootstrap actions") {
+		t.Errorf("expected all-allowed summary after merging pages; stdout=%q", out)
+	}
+}
+
+func TestAWS_AmbientMode_SessionARNMapped(t *testing.T) {
+	actions := []string{"s3:CreateBucket"}
+	withFakeAWSClients(t,
+		&fakeSTS{callerOut: &sts.GetCallerIdentityOutput{
+			Arn: aws.String("arn:aws:sts::123456789012:assumed-role/MyRole/session-xyz"),
+		}},
+		&fakeIAM{pages: []*iam.SimulatePrincipalPolicyOutput{evalPage("", actions, actions...)}},
+	)
+	code, out, errOut := runPreflight(t, "aws", "--actions", strings.Join(actions, ","))
+	if code != exitOK {
+		t.Fatalf("exit = %d, want %d; stderr=\n%s", code, exitOK, errOut)
+	}
+	// Session ARN must be mapped back to the role identity ARN for simulate.
+	if !strings.Contains(out, "ambient caller identity arn:aws:iam::123456789012:role/MyRole") {
+		t.Errorf("caller session ARN was not mapped to the role identity ARN; stdout=%q", out)
+	}
+}
+
+func TestAWS_AmbientMode_GetCallerIdentityError_FailOpen(t *testing.T) {
+	withFakeAWSClients(t,
+		&fakeSTS{callerErr: apiErr("ExpiredToken")},
+		&fakeIAM{},
+	)
+	code, _, errOut := runPreflight(t, "aws", "--actions", "s3:CreateBucket")
+	if code != exitOK {
+		t.Fatalf("exit = %d, want %d (fail-open)", code, exitOK)
+	}
+	if !strings.Contains(errOut, "GetCallerIdentity failed") {
+		t.Errorf("stderr missing GetCallerIdentity fail-open warning; got:\n%s", errOut)
+	}
+}
+
+func TestAWS_IncompleteAssumeCreds_FailOpen(t *testing.T) {
+	withFakeAWSClients(t,
+		&fakeSTS{assumeOut: &sts.AssumeRoleOutput{Credentials: &ststypes.Credentials{
+			AccessKeyId: aws.String("AKIA"), // missing secret + token
+		}}},
+		&fakeIAM{},
+	)
+	code, _, errOut := runPreflight(t, "aws", "--role-arn", testRole, "--actions", "s3:CreateBucket")
+	if code != exitOK {
+		t.Fatalf("exit = %d, want %d (fail-open)", code, exitOK)
+	}
+	if !strings.Contains(errOut, "incomplete credential set") {
+		t.Errorf("stderr missing incomplete-creds fail-open warning; got:\n%s", errOut)
+	}
+}
+
+func TestMapCallerARNToPolicySource(t *testing.T) {
+	cases := []struct {
+		name   string
+		arn    string
+		want   string
+		wantOK bool
+	}{
+		{"aws assumed-role session", "arn:aws:sts::123456789012:assumed-role/MyRole/sess", "arn:aws:iam::123456789012:role/MyRole", true},
+		{"aws-us-gov assumed-role", "arn:aws-us-gov:sts::210987654321:assumed-role/GovRole/sess", "arn:aws-us-gov:iam::210987654321:role/GovRole", true},
+		{"aws-cn assumed-role", "arn:aws-cn:sts::111122223333:assumed-role/CnRole/sess", "arn:aws-cn:iam::111122223333:role/CnRole", true},
+		{"direct iam role passthrough", "arn:aws:iam::123456789012:role/Direct", "arn:aws:iam::123456789012:role/Direct", true},
+		{"direct iam user passthrough", "arn:aws:iam::123456789012:user/alice", "arn:aws:iam::123456789012:user/alice", true},
+		{"aws-cn iam user passthrough", "arn:aws-cn:iam::111122223333:user/bob", "arn:aws-cn:iam::111122223333:user/bob", true},
+		{"root fails open", "arn:aws:iam::123456789012:root", "", false},
+		{"federated-user fails open", "arn:aws:sts::123456789012:federated-user/fed", "", false},
+		{"garbage fails open", "not-an-arn", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := mapCallerARNToPolicySource(tc.arn)
+			if ok != tc.wantOK || got != tc.want {
+				t.Errorf("mapCallerARNToPolicySource(%q) = (%q, %v), want (%q, %v)", tc.arn, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+// runPreflight drives Main end-to-end and captures the split output streams.
+func runPreflight(t *testing.T, args ...string) (code int, stdout, stderr string) {
+	t.Helper()
+	var out, errb bytes.Buffer
+	code = Main(context.Background(), args, &out, &errb)
+	return code, out.String(), errb.String()
+}
+
+// countPrefixLines counts lines beginning with prefix.
+func countPrefixLines(s, prefix string) int {
+	n := 0
+	for _, line := range strings.Split(s, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/preflight/doc.go
+++ b/internal/preflight/doc.go
@@ -43,9 +43,13 @@
 // permission list.
 //
 //   - 200 with a missing subset            → fail-closed, listing the missing perms.
-//   - Invalid/malformed SA key, or a
+//   - Malformed-JSON SA key, or a
 //     definitive token rejection
 //     (invalid_grant / HTTP 401)           → fail-closed (bad-credential message).
+//   - Unloadable key MATERIAL (bad PEM in
+//     otherwise-valid service_account JSON) → fail-open (deferred to the token
+//     fetch, which surfaces an untyped parse error; a deliberate, safe
+//     divergence from the shell — see gcp.go newGCPChecker).
 //   - HTTP 403 on the call itself, HTTP
 //     5xx, network error, timeout          → fail-open.
 //   - Non-service_account JSON type

--- a/internal/preflight/doc.go
+++ b/internal/preflight/doc.go
@@ -1,0 +1,88 @@
+// Package preflight implements the InsideOut bootstrap-permission preflights —
+// a defense-in-depth guard for luthersystems/reliable#2243 (the Beatloom
+// incident): a customer's under-privileged connecting credential passed
+// credential validation and reached the cloud-provision Terraform apply, then
+// 403'd mid-apply on a create action (storage.buckets.create /
+// iam.serviceAccounts.create on GCP; s3:CreateBucket / iam:CreateRole on AWS) —
+// AFTER the GitHub half of that apply had already created a repo, deploy key,
+// and Actions variables, leaving orphaned partial state.
+//
+// This is the Go port of the sandbox-infrastructure-template shell preflights
+// (tf/gcp-preflight.sh, tf/aws-preflight.sh). Those scripts encode the reviewed
+// semantics; this binary reproduces them EXACTLY, replacing shell + jq + gcloud
+// + curl + aws-cli string matching with typed cloud-SDK calls and typed error
+// classification. The template retains ownership of the hook, the
+// SKIP_GCP_BOOTSTRAP_PREFLIGHT / SKIP_AWS_BOOTSTRAP_PREFLIGHT escape hatches,
+// and the canonical permission/action lists — the binary takes those lists as
+// INPUT and supplies only the mechanics.
+//
+// # CLI contract
+//
+// This contract is the interface the template swap PR codes against. It is
+// stable; the output markers below match the shell scripts byte-for-byte so log
+// tooling and the template tests keep working across the swap.
+//
+//	insideout-preflight gcp --project-id <PID> --credentials-file <path to SA JSON> --permissions p1,p2,... [--timeout 30s]
+//	insideout-preflight aws --actions a1,a2,... [--role-arn <ARN> [--external-id <ID>]] [--region r] [--timeout 30s]
+//
+// Permissions/actions accept comma-separated values and/or repeatable flags
+// (--permissions a,b --permissions c); at least one is required.
+//
+// # Exit codes (the whole contract)
+//
+//	0  passed OR fail-open (verdict could not be definitively obtained — a
+//	   prominent WARNING explains why). The template hook treats 0 as non-fatal.
+//	1  definitive fail-closed (missing permissions / actions, or a definitive
+//	   bad-credential rejection). The template hook treats ONLY exit 1 as fatal.
+//	2  usage error (bad flags, empty permission/action list, unreadable
+//	   credentials file).
+//
+// # GCP semantics
+//
+// Calls cloudresourcemanager.projects.testIamPermissions with the supplied
+// permission list.
+//
+//   - 200 with a missing subset            → fail-closed, listing the missing perms.
+//   - Invalid/malformed SA key, or a
+//     definitive token rejection
+//     (invalid_grant / HTTP 401)           → fail-closed (bad-credential message).
+//   - HTTP 403 on the call itself, HTTP
+//     5xx, network error, timeout          → fail-open.
+//   - Non-service_account JSON type
+//     (WIF / external_account)             → fail-open (mirrors the shell's
+//     defensive choice).
+//
+// Owner-grant caveat: the cloud-provision stage grants roles/owner to the
+// InsideOut management service account, and GCP only permits a caller holding
+// Owner to grant Owner. testIamPermissions cannot verify that, so PASSING this
+// preflight does not by itself guarantee the Owner grant will succeed — the
+// fail-closed remediation says so and recommends roles/owner.
+//
+// # AWS semantics
+//
+// With --role-arn: STS AssumeRole (+ external id) using ambient credentials,
+// then iam:SimulatePrincipalPolicy with PolicySourceArn = the role ARN,
+// executed under the assumed-role session credentials. Without --role-arn:
+// resolve the caller via sts:GetCallerIdentity and map an assumed-role SESSION
+// ARN back to the role IDENTITY ARN simulate requires (aws / aws-us-gov / aws-cn
+// partitions; federated / root → fail-open).
+//
+//   - Simulate returns any non-"allowed"
+//     required action                      → fail-closed, listing the denied actions.
+//   - AssumeRole explicit AccessDenied     → fail-closed (distinct trust-policy /
+//     external-id message).
+//   - Any other AssumeRole error
+//     (throttle, 5xx, network, expired
+//     ambient creds)                       → fail-open.
+//   - ANY SimulatePrincipalPolicy error
+//     (incl. AccessDenied on
+//     iam:SimulatePrincipalPolicy)         → fail-open (inability to verify is not
+//     proof of insufficiency).
+//
+// Only EvalDecision == "allowed" counts; the SDK paginator merges results across
+// pages. Failure classification is by typed SDK error (smithy.APIError codes),
+// not string matching.
+//
+// Credential material (SA key contents, session tokens) is never printed. Every
+// cloud API call is bounded by --timeout (default 30s).
+package preflight

--- a/internal/preflight/gcp.go
+++ b/internal/preflight/gcp.go
@@ -1,0 +1,295 @@
+package preflight
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/cloudresourcemanager/v1"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+)
+
+// gcpChecker runs projects.testIamPermissions for the supplied permission list
+// and returns the granted subset. It isolates the single live GCP call so tests
+// can point it at an httptest endpoint.
+type gcpChecker func(ctx context.Context, projectID string, perms []string) (granted []string, err error)
+
+// newGCPChecker builds the production checker from a service-account key. It is a
+// package var so tests can substitute an httptest-backed or synthetic checker.
+//
+// A credential-construction failure (valid JSON, type=service_account, but
+// unusable/garbage key material) is a definitive bad credential, wrapped in
+// *gcpBadCredentialError so runGCP fails closed. A client-construction failure
+// is treated as infra (fail-open).
+var newGCPChecker = defaultGCPChecker
+
+func defaultGCPChecker(ctx context.Context, saJSON []byte) (gcpChecker, error) {
+	// CredentialsFromJSONWithType is the non-deprecated form: it asserts the
+	// JSON is a service-account key and applies the cloud-platform scope. A bad
+	// key surfaces here as a construction error → definitive bad credential.
+	creds, err := google.CredentialsFromJSONWithType(ctx, saJSON, google.ServiceAccount, cloudresourcemanager.CloudPlatformScope)
+	if err != nil {
+		return nil, &gcpBadCredentialError{err: err}
+	}
+	svc, err := cloudresourcemanager.NewService(ctx, option.WithCredentials(creds))
+	if err != nil {
+		return nil, err
+	}
+	return func(ctx context.Context, projectID string, perms []string) ([]string, error) {
+		resp, err := svc.Projects.TestIamPermissions(projectID, &cloudresourcemanager.TestIamPermissionsRequest{
+			Permissions: perms,
+		}).Context(ctx).Do()
+		if err != nil {
+			return nil, err
+		}
+		return resp.Permissions, nil
+	}, nil
+}
+
+// gcpBadCredentialError marks a definitive bad-credential failure (unusable SA
+// key material) so runGCP fails closed rather than fail-open.
+type gcpBadCredentialError struct{ err error }
+
+func (e *gcpBadCredentialError) Error() string { return e.err.Error() }
+func (e *gcpBadCredentialError) Unwrap() error { return e.err }
+
+// gcpCredKind classifies a supplied credential file's content BEFORE any network
+// call, mirroring the shell's jq-based `.type` inspection.
+type gcpCredKind int
+
+const (
+	gcpCredOK             gcpCredKind = iota // valid service_account JSON
+	gcpCredMalformed                         // not parseable as JSON → fail-closed
+	gcpCredNotServiceAcct                    // parses, but type != service_account → fail-open
+)
+
+// gcpCredInfo carries the fields the messages need.
+type gcpCredInfo struct {
+	clientEmail string
+	credType    string
+}
+
+// classifyGCPCredential inspects the raw SA key JSON. It never makes a network
+// call. Malformed JSON is a definitive bad credential (fail-closed); a parseable
+// JSON whose type is not service_account (e.g. WIF/external_account) is
+// fail-open, matching the shell's defensive choice.
+func classifyGCPCredential(raw []byte) (gcpCredInfo, gcpCredKind) {
+	var doc struct {
+		Type        string `json:"type"`
+		ClientEmail string `json:"client_email"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return gcpCredInfo{}, gcpCredMalformed
+	}
+	info := gcpCredInfo{clientEmail: doc.ClientEmail, credType: doc.Type}
+	if doc.Type != "service_account" {
+		return info, gcpCredNotServiceAcct
+	}
+	return info, gcpCredOK
+}
+
+// classifyGCPAPIError decides fail-closed vs fail-open for an error returned by
+// the testIamPermissions call. It prefers typed classification (oauth2 token
+// rejection, googleapi HTTP status) over string matching; the string fallback
+// is a safety net for opaque token-endpoint wrappers.
+//
+//   - oauth2 token rejection / HTTP 401  → fail-closed (definitive bad credential).
+//   - HTTP 403 / 5xx / other non-200     → fail-open (not a permission verdict).
+//   - context deadline / cancellation    → fail-open.
+//   - anything else (network/transport)  → fail-open.
+func classifyGCPAPIError(err error) (failClosed bool, detail string) {
+	if err == nil {
+		return false, ""
+	}
+	// A token-exchange rejection (revoked/deleted SA, invalid_grant) surfaces as
+	// *oauth2.RetrieveError — a definitive bad-credential verdict.
+	var re *oauth2.RetrieveError
+	if errors.As(err, &re) {
+		return true, strings.TrimSpace(re.Error())
+	}
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) {
+		switch gerr.Code {
+		case 401:
+			return true, strings.TrimSpace(gerr.Error())
+		case 403:
+			return false, "testIamPermissions returned HTTP 403 (not a permission verdict; treating as infra/transient)."
+		default:
+			return false, fmt.Sprintf("testIamPermissions returned HTTP %d (not a permission verdict; treating as infra/transient).", gerr.Code)
+		}
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return false, "testIamPermissions call timed out (treating as infra/transient)."
+	}
+	// Safety net: definitive OAuth token rejections occasionally arrive as opaque
+	// errors that do not unwrap to *oauth2.RetrieveError. Mirror the shell's grep
+	// for the canonical token-endpoint error codes.
+	low := strings.ToLower(err.Error())
+	for _, tok := range []string{"invalid_grant", "invalid_client", "unauthorized_client"} {
+		if strings.Contains(low, tok) {
+			return true, strings.TrimSpace(err.Error())
+		}
+	}
+	return false, "testIamPermissions call failed (network/transport error): " + err.Error()
+}
+
+// runGCP parses the gcp subcommand flags and runs the GCP bootstrap-permission
+// preflight, returning the process exit code.
+func runGCP(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	l := logger{prefix: gcpPrefix, out: stdout, err: stderr}
+
+	fs := flag.NewFlagSet("insideout-preflight gcp", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		projectID = fs.String("project-id", "", "GCP project id to check bootstrap permissions on")
+		credsFile = fs.String("credentials-file", "", "path to the service-account key JSON")
+		timeout   = fs.Duration("timeout", 30*time.Second, "per-call timeout")
+		perms     stringList
+	)
+	fs.Var(&perms, "permissions", "required bootstrap permissions (comma-separated and/or repeatable)")
+	if code, ok := parseFlags(fs, args); !ok {
+		return code
+	}
+
+	if strings.TrimSpace(*projectID) == "" {
+		fprintln(stderr, "insideout-preflight gcp: --project-id is required")
+		return exitUsage
+	}
+	if strings.TrimSpace(*credsFile) == "" {
+		fprintln(stderr, "insideout-preflight gcp: --credentials-file is required")
+		return exitUsage
+	}
+	if len(perms) == 0 {
+		fprintln(stderr, "insideout-preflight gcp: --permissions must not be empty")
+		return exitUsage
+	}
+
+	raw, err := os.ReadFile(*credsFile)
+	if err != nil {
+		// An unreadable credentials FILE is a usage error, distinct from an
+		// unreadable-KEY (malformed content), which is a fail-closed verdict.
+		fprintf(stderr, "insideout-preflight gcp: cannot read --credentials-file %q: %v\n", *credsFile, err)
+		return exitUsage
+	}
+
+	info, kind := classifyGCPCredential(raw)
+	switch kind {
+	case gcpCredMalformed:
+		return l.gcpFailLoadKey("unknown", "the service account key JSON is not parseable")
+	case gcpCredNotServiceAcct:
+		return l.failOpen(fmt.Sprintf("credential type '%s' is not 'service_account' (WIF/external_account?) — skipping token mint.", info.credType), skipGCP)
+	}
+
+	saEmail := info.clientEmail
+	if saEmail == "" {
+		saEmail = "unknown"
+	}
+	l.outln(fmt.Sprintf("checking bootstrap permissions for service account %s on project %s", saEmail, *projectID))
+
+	checker, err := newGCPChecker(ctx, raw)
+	if err != nil {
+		var bad *gcpBadCredentialError
+		if errors.As(err, &bad) {
+			return l.gcpFailLoadKey(saEmail, bad.Error())
+		}
+		return l.failOpen("could not initialize cloudresourcemanager client: "+err.Error(), skipGCP)
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, *timeout)
+	defer cancel()
+	granted, err := checker(callCtx, *projectID, perms)
+	if err != nil {
+		failClosed, detail := classifyGCPAPIError(err)
+		if failClosed {
+			return l.gcpFailTokenRejected(saEmail, detail)
+		}
+		return l.failOpen(detail, skipGCP)
+	}
+
+	missing := missingItems(perms, granted)
+	if len(missing) == 0 {
+		l.outln(fmt.Sprintf("OK — service account %s holds all %d bootstrap permissions on project %s.", saEmail, len(perms), *projectID))
+		return exitOK
+	}
+	return l.gcpFailMissing(saEmail, *projectID, missing)
+}
+
+// missingItems returns the required items absent from the granted set, in the
+// required-list order.
+func missingItems(required, granted []string) []string {
+	have := make(map[string]bool, len(granted))
+	for _, g := range granted {
+		have[g] = true
+	}
+	var missing []string
+	for _, r := range required {
+		if !have[r] {
+			missing = append(missing, r)
+		}
+	}
+	return missing
+}
+
+// gcpFailMissing prints the definitive missing-permission verdict (fail-closed,
+// exit 1). The block matches tf/gcp-preflight.sh byte-for-byte, including the
+// roles/owner Owner-grant caveat.
+func (l logger) gcpFailMissing(saEmail, projectID string, missing []string) int {
+	l.errln("")
+	l.errln("================================================================")
+	l.errln("GCP BOOTSTRAP PREFLIGHT FAILED — the provided service account")
+	l.errln(fmt.Sprintf("%s is missing %d required permission(s) on project %s:", saEmail, len(missing), projectID))
+	for _, perm := range missing {
+		l.errln("  - " + perm)
+	}
+	l.errln("")
+	l.errln("Grant the service account roles/owner on the project (required anyway:")
+	l.errln("this bootstrap stage grants Owner to the InsideOut management service")
+	l.errln("account, which GCP only permits from a caller that itself holds Owner;")
+	l.errln("testIamPermissions cannot verify that, so passing this preflight does not")
+	l.errln("by itself guarantee the Owner grant will succeed).")
+	l.errln("")
+	l.errln("At minimum grant: roles/storage.admin + roles/iam.serviceAccountAdmin +")
+	l.errln("roles/resourcemanager.projectIamAdmin — then re-run the deploy.")
+	l.errln("")
+	l.errln("Escape hatch: set SKIP_GCP_BOOTSTRAP_PREFLIGHT=1 to bypass this check.")
+	l.errln("Ref: luthersystems/reliable#2243.")
+	l.errln("================================================================")
+	return exitFail
+}
+
+// gcpFailLoadKey prints the bad-key fail-closed verdict (a key that cannot be
+// loaded — malformed / revoked / invalid material). Matches the shell's
+// activate-service-account failure block.
+func (l logger) gcpFailLoadKey(saEmail, detail string) int {
+	l.errln("")
+	l.errln("GCP BOOTSTRAP PREFLIGHT FAILED — could not load the service account key")
+	l.errln(fmt.Sprintf("for %s: the key is malformed, revoked, or invalid.", saEmail))
+	if strings.TrimSpace(detail) != "" {
+		l.errln(detail)
+	}
+	l.errln("Ref: luthersystems/reliable#2243.")
+	return exitFail
+}
+
+// gcpFailTokenRejected prints the token-rejection fail-closed verdict (bad /
+// revoked key rejected at token exchange or with HTTP 401). Matches the shell's
+// token-exchange rejection block.
+func (l logger) gcpFailTokenRejected(saEmail, detail string) int {
+	l.errln("")
+	l.errln("GCP BOOTSTRAP PREFLIGHT FAILED — token exchange was REJECTED for")
+	l.errln(fmt.Sprintf("%s (bad / revoked service account key):", saEmail))
+	if strings.TrimSpace(detail) != "" {
+		l.errln(detail)
+	}
+	l.errln("Ref: luthersystems/reliable#2243.")
+	return exitFail
+}

--- a/internal/preflight/gcp.go
+++ b/internal/preflight/gcp.go
@@ -26,16 +26,26 @@ type gcpChecker func(ctx context.Context, projectID string, perms []string) (gra
 // newGCPChecker builds the production checker from a service-account key. It is a
 // package var so tests can substitute an httptest-backed or synthetic checker.
 //
-// A credential-construction failure (valid JSON, type=service_account, but
-// unusable/garbage key material) is a definitive bad credential, wrapped in
-// *gcpBadCredentialError so runGCP fails closed. A client-construction failure
-// is treated as infra (fail-open).
+// A structural construction failure — JSON that clears classifyGCPCredential's
+// lenient {type,client_email} parse yet fails CredentialsFromJSONWithType's full
+// decode (e.g. a wrong-typed field) — is a definitive bad credential, wrapped in
+// *gcpBadCredentialError so runGCP fails closed. Note this does NOT include
+// garbage key MATERIAL: CredentialsFromJSONWithType builds a lazy JWT token
+// source and never parses the private_key PEM, so an unloadable key does not
+// error here — it surfaces on the first token fetch inside the checker call and
+// is classified by classifyGCPAPIError (token-endpoint rejection → fail-closed;
+// a locally-unparseable PEM → fail-open). That is a deliberate, safe divergence
+// from the shell's gcloud-activate fail-closed: such a key is already rejected
+// upstream (Oracle authenticates it at credential-validate; setupGCPCredentials
+// re-checks .type), and even if one reached here terraform would fail at plan
+// before creating anything. A client-construction failure is infra (fail-open).
 var newGCPChecker = defaultGCPChecker
 
 func defaultGCPChecker(ctx context.Context, saJSON []byte) (gcpChecker, error) {
 	// CredentialsFromJSONWithType is the non-deprecated form: it asserts the
-	// JSON is a service-account key and applies the cloud-platform scope. A bad
-	// key surfaces here as a construction error → definitive bad credential.
+	// JSON is a service-account key and applies the cloud-platform scope. Only a
+	// structural decode failure errors here (→ definitive bad credential);
+	// garbage key material is deferred to the first token fetch (see above).
 	creds, err := google.CredentialsFromJSONWithType(ctx, saJSON, google.ServiceAccount, cloudresourcemanager.CloudPlatformScope)
 	if err != nil {
 		return nil, &gcpBadCredentialError{err: err}
@@ -55,8 +65,10 @@ func defaultGCPChecker(ctx context.Context, saJSON []byte) (gcpChecker, error) {
 	}, nil
 }
 
-// gcpBadCredentialError marks a definitive bad-credential failure (unusable SA
-// key material) so runGCP fails closed rather than fail-open.
+// gcpBadCredentialError marks a definitive construction-time bad-credential
+// failure (a structural decode failure in CredentialsFromJSONWithType) so runGCP
+// fails closed rather than fail-open. Garbage key MATERIAL is not detected at
+// construction — see newGCPChecker and classifyGCPAPIError.
 type gcpBadCredentialError struct{ err error }
 
 func (e *gcpBadCredentialError) Error() string { return e.err.Error() }

--- a/internal/preflight/gcp_test.go
+++ b/internal/preflight/gcp_test.go
@@ -1,0 +1,281 @@
+package preflight
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+	"google.golang.org/api/cloudresourcemanager/v1"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+)
+
+// minimal service-account JSON that passes classifyGCPCredential (type check)
+// without any real key material — the httptest-backed checker ignores it.
+const testSAJSON = `{"type":"service_account","client_email":"sa@test.iam.gserviceaccount.com"}`
+
+// testIamServer stands up a fake cloudresourcemanager testIamPermissions
+// endpoint. handler receives the requested permissions and returns the HTTP
+// status, the granted subset (for 200s), and an optional delay.
+func testIamServer(t *testing.T, handler func(perms []string) (status int, granted []string, delay time.Duration)) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, ":testIamPermissions") {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		var req struct {
+			Permissions []string `json:"permissions"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		status, granted, delay := handler(req.Permissions)
+		if delay > 0 {
+			time.Sleep(delay)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(`{"error":{"code":` + strconv.Itoa(status) + `,"message":"boom"}}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string][]string{"permissions": granted})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// withGCPEndpoint points newGCPChecker at a fake endpoint using an
+// unauthenticated real cloudresourcemanager client, exercising the real request
+// build + response parse + classification path with no credentials.
+func withGCPEndpoint(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	orig := newGCPChecker
+	newGCPChecker = func(ctx context.Context, _ []byte) (gcpChecker, error) {
+		svc, err := cloudresourcemanager.NewService(ctx, option.WithoutAuthentication(), option.WithEndpoint(srv.URL))
+		if err != nil {
+			return nil, err
+		}
+		return func(ctx context.Context, projectID string, perms []string) ([]string, error) {
+			resp, err := svc.Projects.TestIamPermissions(projectID, &cloudresourcemanager.TestIamPermissionsRequest{
+				Permissions: perms,
+			}).Context(ctx).Do()
+			if err != nil {
+				return nil, err
+			}
+			return resp.Permissions, nil
+		}, nil
+	}
+	t.Cleanup(func() { newGCPChecker = orig })
+}
+
+// writeSAKey writes an SA-key file and returns its path.
+func writeSAKey(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "sa.json")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write sa key: %v", err)
+	}
+	return path
+}
+
+func TestGCP_AllPermissionsGranted(t *testing.T) {
+	perms := []string{"storage.buckets.create", "iam.serviceAccounts.create", "resourcemanager.projects.get"}
+	withGCPEndpoint(t, testIamServer(t, func(reqPerms []string) (int, []string, time.Duration) {
+		return http.StatusOK, reqPerms, 0 // grant everything requested
+	}))
+	sa := writeSAKey(t, testSAJSON)
+	code, out, errOut := runPreflight(t, "gcp", "--project-id", "p1", "--credentials-file", sa, "--permissions", strings.Join(perms, ","))
+	if code != exitOK {
+		t.Fatalf("exit = %d, want %d; stderr=\n%s", code, exitOK, errOut)
+	}
+	if !strings.Contains(out, "holds all 3 bootstrap permissions") {
+		t.Errorf("missing OK summary; stdout=%q", out)
+	}
+}
+
+func TestGCP_MissingSubset_FailClosed(t *testing.T) {
+	perms := []string{"storage.buckets.create", "iam.serviceAccounts.create", "resourcemanager.projects.get"}
+	withGCPEndpoint(t, testIamServer(t, func(_ []string) (int, []string, time.Duration) {
+		// grant only the read; withhold the two #2243 create permissions
+		return http.StatusOK, []string{"resourcemanager.projects.get"}, 0
+	}))
+	sa := writeSAKey(t, testSAJSON)
+	code, _, errOut := runPreflight(t, "gcp", "--project-id", "p1", "--credentials-file", sa, "--permissions", strings.Join(perms, ","))
+	if code != exitFail {
+		t.Fatalf("exit = %d, want %d; stderr=\n%s", code, exitFail, errOut)
+	}
+	for _, want := range []string{
+		"GCP BOOTSTRAP PREFLIGHT FAILED — the provided service account",
+		"storage.buckets.create",
+		"iam.serviceAccounts.create",
+		"roles/owner",
+		"reliable#2243",
+	} {
+		if !strings.Contains(errOut, want) {
+			t.Errorf("stderr missing %q; got:\n%s", want, errOut)
+		}
+	}
+	if got := countPrefixLines(errOut, gcpPrefix+"  - "); got != 2 {
+		t.Errorf("missing-permission listing lines = %d, want 2; stderr=\n%s", got, errOut)
+	}
+	if strings.Contains(errOut, gcpPrefix+"  - resourcemanager.projects.get") {
+		t.Errorf("granted permission must not appear in the missing listing")
+	}
+}
+
+func TestGCP_HTTP403_FailOpen(t *testing.T) {
+	withGCPEndpoint(t, testIamServer(t, func(_ []string) (int, []string, time.Duration) {
+		return http.StatusForbidden, nil, 0
+	}))
+	sa := writeSAKey(t, testSAJSON)
+	code, _, errOut := runPreflight(t, "gcp", "--project-id", "p1", "--credentials-file", sa, "--permissions", "storage.buckets.create")
+	if code != exitOK {
+		t.Fatalf("exit = %d, want %d (fail-open); stderr=\n%s", code, exitOK, errOut)
+	}
+	if !strings.Contains(errOut, "WARNING") || !strings.Contains(errOut, "HTTP 403") {
+		t.Errorf("stderr missing 403 fail-open warning; got:\n%s", errOut)
+	}
+}
+
+func TestGCP_HTTP500_FailOpen(t *testing.T) {
+	withGCPEndpoint(t, testIamServer(t, func(_ []string) (int, []string, time.Duration) {
+		return http.StatusInternalServerError, nil, 0
+	}))
+	sa := writeSAKey(t, testSAJSON)
+	code, _, errOut := runPreflight(t, "gcp", "--project-id", "p1", "--credentials-file", sa, "--permissions", "storage.buckets.create")
+	if code != exitOK {
+		t.Fatalf("exit = %d, want %d (fail-open); stderr=\n%s", code, exitOK, errOut)
+	}
+	if !strings.Contains(errOut, "WARNING") || !strings.Contains(errOut, "HTTP 500") {
+		t.Errorf("stderr missing 500 fail-open warning; got:\n%s", errOut)
+	}
+}
+
+func TestGCP_Timeout_FailOpen(t *testing.T) {
+	withGCPEndpoint(t, testIamServer(t, func(reqPerms []string) (int, []string, time.Duration) {
+		return http.StatusOK, reqPerms, 500 * time.Millisecond // exceed the --timeout below
+	}))
+	sa := writeSAKey(t, testSAJSON)
+	code, _, errOut := runPreflight(t, "gcp", "--project-id", "p1", "--credentials-file", sa, "--permissions", "storage.buckets.create", "--timeout", "100ms")
+	if code != exitOK {
+		t.Fatalf("exit = %d, want %d (fail-open); stderr=\n%s", code, exitOK, errOut)
+	}
+	if !strings.Contains(errOut, "WARNING") {
+		t.Errorf("stderr missing timeout fail-open warning; got:\n%s", errOut)
+	}
+}
+
+func TestGCP_MalformedKeyFile_FailClosed(t *testing.T) {
+	// Unparseable JSON is a definitive bad credential — no network call.
+	sa := writeSAKey(t, "not-json-at-all")
+	code, _, errOut := runPreflight(t, "gcp", "--project-id", "p1", "--credentials-file", sa, "--permissions", "storage.buckets.create")
+	if code != exitFail {
+		t.Fatalf("exit = %d, want %d; stderr=\n%s", code, exitFail, errOut)
+	}
+	for _, want := range []string{"could not load the service account key", "malformed", "reliable#2243"} {
+		if !strings.Contains(errOut, want) {
+			t.Errorf("stderr missing %q; got:\n%s", want, errOut)
+		}
+	}
+}
+
+func TestGCP_NonServiceAccountType_FailOpen(t *testing.T) {
+	sa := writeSAKey(t, `{"type":"external_account","audience":"//iam.googleapis.com/..."}`)
+	code, _, errOut := runPreflight(t, "gcp", "--project-id", "p1", "--credentials-file", sa, "--permissions", "storage.buckets.create")
+	if code != exitOK {
+		t.Fatalf("exit = %d, want %d (fail-open); stderr=\n%s", code, exitOK, errOut)
+	}
+	if !strings.Contains(errOut, "WARNING") || !strings.Contains(errOut, "not 'service_account'") {
+		t.Errorf("stderr missing non-service_account fail-open warning; got:\n%s", errOut)
+	}
+}
+
+func TestGCP_BadCredentialFromFactory_FailClosed(t *testing.T) {
+	orig := newGCPChecker
+	newGCPChecker = func(context.Context, []byte) (gcpChecker, error) {
+		return nil, &gcpBadCredentialError{err: errors.New("could not parse key: bad PEM")}
+	}
+	t.Cleanup(func() { newGCPChecker = orig })
+
+	sa := writeSAKey(t, testSAJSON)
+	code, _, errOut := runPreflight(t, "gcp", "--project-id", "p1", "--credentials-file", sa, "--permissions", "storage.buckets.create")
+	if code != exitFail {
+		t.Fatalf("exit = %d, want %d; stderr=\n%s", code, exitFail, errOut)
+	}
+	if !strings.Contains(errOut, "could not load the service account key") {
+		t.Errorf("stderr missing bad-key fail-closed block; got:\n%s", errOut)
+	}
+}
+
+func TestClassifyGCPCredential(t *testing.T) {
+	cases := []struct {
+		name      string
+		raw       string
+		wantKind  gcpCredKind
+		wantEmail string
+		wantType  string
+	}{
+		{"valid service_account", `{"type":"service_account","client_email":"sa@x.iam"}`, gcpCredOK, "sa@x.iam", "service_account"},
+		{"malformed json", `not-json`, gcpCredMalformed, "", ""},
+		{"external_account", `{"type":"external_account"}`, gcpCredNotServiceAcct, "", "external_account"},
+		{"empty type", `{"client_email":"sa@x.iam"}`, gcpCredNotServiceAcct, "sa@x.iam", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			info, kind := classifyGCPCredential([]byte(tc.raw))
+			if kind != tc.wantKind {
+				t.Errorf("kind = %v, want %v", kind, tc.wantKind)
+			}
+			if kind != gcpCredMalformed {
+				if info.clientEmail != tc.wantEmail {
+					t.Errorf("clientEmail = %q, want %q", info.clientEmail, tc.wantEmail)
+				}
+				if info.credType != tc.wantType {
+					t.Errorf("credType = %q, want %q", info.credType, tc.wantType)
+				}
+			}
+		})
+	}
+}
+
+func TestClassifyGCPAPIError(t *testing.T) {
+	tokenReject := &oauth2.RetrieveError{
+		Response:  &http.Response{Status: "400 Bad Request", StatusCode: 400},
+		Body:      []byte(`{"error":"invalid_grant"}`),
+		ErrorCode: "invalid_grant",
+	}
+	cases := []struct {
+		name           string
+		err            error
+		wantFailClosed bool
+		wantDetailSub  string
+	}{
+		{"oauth2 token rejection", tokenReject, true, ""},
+		{"googleapi 401", &googleapi.Error{Code: 401, Message: "unauthenticated"}, true, ""},
+		{"googleapi 403", &googleapi.Error{Code: 403, Message: "denied"}, false, "HTTP 403"},
+		{"googleapi 500", &googleapi.Error{Code: 500, Message: "boom"}, false, "HTTP 500"},
+		{"deadline exceeded", context.DeadlineExceeded, false, "timed out"},
+		{"generic network error", errors.New("connection refused"), false, "network/transport"},
+		{"opaque invalid_grant fallback", errors.New("oauth2: cannot fetch token: invalid_grant"), true, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			closed, detail := classifyGCPAPIError(tc.err)
+			if closed != tc.wantFailClosed {
+				t.Errorf("failClosed = %v, want %v (detail=%q)", closed, tc.wantFailClosed, detail)
+			}
+			if tc.wantDetailSub != "" && !strings.Contains(detail, tc.wantDetailSub) {
+				t.Errorf("detail %q missing %q", detail, tc.wantDetailSub)
+			}
+		})
+	}
+}

--- a/internal/preflight/gcp_test.go
+++ b/internal/preflight/gcp_test.go
@@ -216,6 +216,27 @@ func TestGCP_BadCredentialFromFactory_FailClosed(t *testing.T) {
 	}
 }
 
+// TestMainRecoversPanic_FailOpen pins the panic contract: an internal panic in
+// a subcommand is recovered and converted to fail-open (exit 0), never an
+// uncaught non-zero process abort a hook might treat as fatal. Uses the
+// newGCPChecker seam to inject a panic on the live-call path.
+func TestMainRecoversPanic_FailOpen(t *testing.T) {
+	orig := newGCPChecker
+	newGCPChecker = func(context.Context, []byte) (gcpChecker, error) {
+		panic("boom: simulated internal failure")
+	}
+	t.Cleanup(func() { newGCPChecker = orig })
+
+	sa := writeSAKey(t, testSAJSON)
+	code, _, errOut := runPreflight(t, "gcp", "--project-id", "p1", "--credentials-file", sa, "--permissions", "storage.buckets.create")
+	if code != exitOK {
+		t.Fatalf("panic path exit = %d, want %d (fail-open); stderr=\n%s", code, exitOK, errOut)
+	}
+	if !strings.Contains(errOut, "WARNING") || !strings.Contains(errOut, "internal error") {
+		t.Errorf("stderr missing panic fail-open warning; got:\n%s", errOut)
+	}
+}
+
 func TestClassifyGCPCredential(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -33,7 +33,20 @@ const (
 
 // Main is the binary entry point. It dispatches on the first argument to the
 // gcp or aws subcommand and returns the process exit code.
-func Main(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+//
+// A panic in any subcommand is recovered here and converted to fail-open (exit
+// 0). The preflight is advisory, so a bug in our OWN mechanics must never brick
+// a deploy: an uncaught panic would abort the process with a non-zero status
+// (Go uses 2) that a hook could treat as fatal, whereas exit 0 is universally
+// non-fatal. Recovering also avoids dumping a raw stack trace into deploy logs.
+func Main(ctx context.Context, args []string, stdout, stderr io.Writer) (code int) {
+	defer func() {
+		if r := recover(); r != nil {
+			fprintf(stderr, "[insideout-preflight] WARNING: internal error (%v) — preflight is advisory, continuing (deploy NOT blocked).\n", r)
+			code = exitOK
+		}
+	}()
+
 	if len(args) == 0 {
 		printUsage(stderr)
 		return exitUsage

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -1,0 +1,130 @@
+package preflight
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Exit codes — the whole contract. See the package doc.
+const (
+	exitOK    = 0 // passed OR fail-open
+	exitFail  = 1 // definitive fail-closed
+	exitUsage = 2 // usage error
+)
+
+// Escape-hatch env var names. The template hook honors these (it just does not
+// invoke the binary when set); the binary references them in remediation text
+// so the byte-for-byte failure blocks match the shell scripts.
+const (
+	skipGCP = "SKIP_GCP_BOOTSTRAP_PREFLIGHT"
+	skipAWS = "SKIP_AWS_BOOTSTRAP_PREFLIGHT"
+)
+
+// Log prefixes — must match the shell scripts byte-for-byte (log tooling and
+// the template tests grep on these, e.g. `^\[gcp-preflight\]   - `).
+const (
+	gcpPrefix = "[gcp-preflight] "
+	awsPrefix = "[aws-preflight] "
+)
+
+// Main is the binary entry point. It dispatches on the first argument to the
+// gcp or aws subcommand and returns the process exit code.
+func Main(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		printUsage(stderr)
+		return exitUsage
+	}
+	switch args[0] {
+	case "gcp":
+		return runGCP(ctx, args[1:], stdout, stderr)
+	case "aws":
+		return runAWS(ctx, args[1:], stdout, stderr)
+	case "-h", "--help", "help":
+		printUsage(stdout)
+		return exitOK
+	default:
+		fprintf(stderr, "insideout-preflight: unknown subcommand %q\n", args[0])
+		printUsage(stderr)
+		return exitUsage
+	}
+}
+
+// fprintf / fprintln write to w, discarding the write error. A failed write to a
+// terminal/pipe on usage or diagnostic output is not actionable, so these keep
+// the call sites uncluttered while staying errcheck-clean.
+func fprintf(w io.Writer, format string, a ...any) { _, _ = fmt.Fprintf(w, format, a...) }
+func fprintln(w io.Writer, a ...any)               { _, _ = fmt.Fprintln(w, a...) }
+
+func printUsage(w io.Writer) {
+	_, _ = fmt.Fprint(w, `insideout-preflight — InsideOut bootstrap-permission preflight (reliable#2243)
+
+Usage:
+  insideout-preflight gcp --project-id <PID> --credentials-file <SA-JSON> --permissions p1,p2,... [--timeout 30s]
+  insideout-preflight aws --actions a1,a2,... [--role-arn <ARN> [--external-id <ID>]] [--region <r>] [--timeout 30s]
+
+Exit codes:
+  0  passed OR fail-open (advisory warning; deploy not blocked)
+  1  definitive fail-closed (missing permissions/actions or bad credential)
+  2  usage error (bad flags, empty list, unreadable credentials file)
+`)
+}
+
+// stringList is a flag.Value that accepts comma-separated values and/or repeated
+// flags, e.g. `--permissions a,b --permissions c` → [a b c]. Blank entries are
+// dropped.
+type stringList []string
+
+func (s *stringList) String() string { return strings.Join(*s, ",") }
+
+func (s *stringList) Set(v string) error {
+	for _, part := range strings.Split(v, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			*s = append(*s, part)
+		}
+	}
+	return nil
+}
+
+// parseFlags parses a subcommand's flag set, translating flag errors into the
+// usage exit code. ok=false means the caller should return the code as-is
+// (either exitUsage on error or exitOK on -h/--help).
+func parseFlags(fs *flag.FlagSet, args []string) (code int, ok bool) {
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return exitOK, false
+		}
+		return exitUsage, false
+	}
+	return exitOK, true
+}
+
+// logger writes prefixed lines to the info (stdout) and warn/error (stderr)
+// streams, reproducing the shell scripts' log()/err() split. Info lines
+// (progress, OK) go to out; warnings and failure blocks go to err.
+type logger struct {
+	prefix string
+	out    io.Writer
+	err    io.Writer
+}
+
+// outln writes an informational, prefixed line to stdout.
+func (l logger) outln(s string) { fprintln(l.out, l.prefix+s) }
+
+// errln writes a warning/error, prefixed line to stderr. An empty s reproduces
+// the shell's `err ""` blank separator (prefix only).
+func (l logger) errln(s string) { fprintln(l.err, l.prefix+s) }
+
+// failOpen logs the advisory warning trio and returns exitOK. The preflight
+// never blocks a deploy on its own flakiness (network, tooling, inability to
+// verify). skipVar names the operator escape hatch for the closing line.
+func (l logger) failOpen(reason, skipVar string) int {
+	l.errln("WARNING: " + reason)
+	l.errln("WARNING: preflight is advisory — continuing (deploy NOT blocked).")
+	l.errln("WARNING: set " + skipVar + "=1 to silence this check.")
+	return exitOK
+}

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -1,0 +1,69 @@
+package preflight
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestUsageErrors pins the exit-code contract: bad flags, empty subcommands,
+// empty permission/action lists, and an unreadable credentials file all return
+// the usage exit code (2).
+func TestUsageErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"no arguments", nil},
+		{"unknown subcommand", []string{"azure", "--foo"}},
+		{"gcp missing project-id", []string{"gcp", "--credentials-file", "/nope", "--permissions", "a"}},
+		{"gcp missing credentials-file", []string{"gcp", "--project-id", "p", "--permissions", "a"}},
+		{"gcp empty permissions", []string{"gcp", "--project-id", "p", "--credentials-file", "/nope"}},
+		{"gcp unreadable credentials file", []string{"gcp", "--project-id", "p", "--credentials-file", "/does/not/exist.json", "--permissions", "a"}},
+		{"gcp unknown flag", []string{"gcp", "--bogus"}},
+		{"aws empty actions", []string{"aws", "--role-arn", "arn:aws:iam::1:role/x"}},
+		{"aws unknown flag", []string{"aws", "--bogus"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, _, _ := runPreflight(t, tc.args...)
+			if code != exitUsage {
+				t.Errorf("Main(%v) = %d, want %d (usage)", tc.args, code, exitUsage)
+			}
+		})
+	}
+}
+
+// TestHelpExitsZero confirms the top-level help path returns exit 0.
+func TestHelpExitsZero(t *testing.T) {
+	for _, arg := range []string{"-h", "--help", "help"} {
+		if code, _, _ := runPreflight(t, arg); code != exitOK {
+			t.Errorf("Main(%q) = %d, want %d", arg, code, exitOK)
+		}
+	}
+}
+
+// TestStringListParsing pins comma-splitting + repeat accumulation + blank drop.
+func TestStringListParsing(t *testing.T) {
+	cases := []struct {
+		name string
+		sets []string
+		want []string
+	}{
+		{"comma separated", []string{"a,b,c"}, []string{"a", "b", "c"}},
+		{"repeated", []string{"a", "b", "c"}, []string{"a", "b", "c"}},
+		{"mixed with spaces and blanks", []string{" a , b ", "", "c,"}, []string{"a", "b", "c"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var s stringList
+			for _, v := range tc.sets {
+				if err := s.Set(v); err != nil {
+					t.Fatalf("Set(%q): %v", v, err)
+				}
+			}
+			if !reflect.DeepEqual([]string(s), tc.want) {
+				t.Errorf("stringList = %v, want %v", []string(s), tc.want)
+			}
+		})
+	}
+}

--- a/scripts/smoke-preflight.sh
+++ b/scripts/smoke-preflight.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Verify the mars image ships a working insideout-preflight binary and that
+# its exit-code contract holds inside the image, with no cloud credentials.
+# The contract (internal/preflight/doc.go) is load-bearing for the
+# sandbox-infrastructure-template hook, which treats ONLY exit 1 as fatal:
+#   0 = passed OR fail-open, 1 = definitive fail-closed, 2 = usage error.
+# Ref: luthersystems/reliable#2243.
+#
+# Fails on:
+#   - binary missing from /usr/local/bin or /opt/bin, or not executable
+#   - any deviation from the credential-free exit-code expectations below
+set -euo pipefail
+
+IMAGE="${1:?usage: smoke-preflight.sh <image>}"
+
+docker run --rm --entrypoint /bin/bash "${IMAGE}" -c '
+set -uo pipefail
+
+fail=0
+
+for p in /usr/local/bin/insideout-preflight /opt/bin/insideout-preflight; do
+  if [ -x "${p}" ]; then
+    echo "OK:   ${p} present and executable"
+  else
+    echo "FAIL: ${p} missing or not executable"
+    fail=1
+  fi
+done
+
+# (description, expected exit code, command...)
+check() {
+  desc="$1"; want="$2"; shift 2
+  set +e
+  "$@" >/dev/null 2>&1
+  got=$?
+  set -e
+  if [ "${got}" -eq "${want}" ]; then
+    echo "OK:   ${desc} (exit ${got})"
+  else
+    echo "FAIL: ${desc}: exit ${got}, want ${want}"
+    fail=1
+  fi
+}
+
+PF=/usr/local/bin/insideout-preflight
+
+# Usage errors -> 2 (non-fatal to the template hook).
+check "bare invocation is a usage error" 2 "${PF}"
+check "aws without --actions is a usage error" 2 "${PF}" aws
+check "gcp with unreadable credentials file is a usage error" 2 \
+  "${PF}" gcp --project-id x --credentials-file /nonexistent --permissions p
+
+# Help -> 0.
+check "--help exits zero" 0 "${PF}" --help
+
+# Malformed SA-key JSON -> definitive fail-closed (exit 1), no network.
+tmp=$(mktemp)
+echo "not json" > "${tmp}"
+check "gcp with malformed key JSON fails closed" 1 \
+  "${PF}" gcp --project-id x --credentials-file "${tmp}" --permissions p
+rm -f "${tmp}"
+
+# No ambient AWS credentials -> credential-resolution error -> fail-open
+# (exit 0). AWS_EC2_METADATA_DISABLED avoids a slow IMDS probe on runners.
+check "aws with no ambient credentials fails open" 0 \
+  env AWS_EC2_METADATA_DISABLED=true AWS_REGION=us-east-1 \
+  "${PF}" aws --actions s3:CreateBucket
+
+exit ${fail}
+'


### PR DESCRIPTION
Part of the luthersystems/reliable#2243 chain. sandbox-infrastructure-template#151 adds fail-fast bootstrap-permission preflights as shell (gcloud/curl/jq); this PR ports the mechanics to Go with typed SDK error classification, following the `insideout-reverse-import` standalone-binary precedent. A follow-up template PR will swap the shell script internals to call this binary (with fail-open fallback when it's absent), after this merges, a release is cut, and ui-core bumps `marsVersion`.

Design split: the binary takes the permission/action lists as input — the lists stay in the template where they change atomically with the terraform they're derived from; mars supplies only the generic check mechanics.

## CLI contract (documented in `internal/preflight/doc.go`)

```
insideout-preflight gcp --project-id <PID> --credentials-file <SA JSON> --permissions p1,p2,... [--timeout 30s]
insideout-preflight aws --actions a1,a2,... [--role-arn <ARN> [--external-id <ID>]] [--region r] [--timeout 30s]
```

Exit codes are the load-bearing interface: `0` = passed or fail-open (warning printed), `1` = definitive fail-closed, `2` = usage error. The template hook treats only exit 1 as fatal. A recovered panic exits 0 (fail-open) so the binary can never brick a deploy on its own defect.

## Semantics (ported from the reviewed shell scripts)

- GCP: `cloudresourcemanager.projects.testIamPermissions`. Missing permissions on a 200 → fail-closed listing each one + roles/owner remediation (with the Owner-grant caveat). Token rejection (`invalid_grant`/401, typed via `*oauth2.RetrieveError` / `*googleapi.Error`) → fail-closed. 403-on-call / 5xx / network / timeout → fail-open.
- AWS: STS AssumeRole (+external id) then `SimulatePrincipalPolicy` (paginated; only `allowed` counts; actions absent from results are treated denied). AssumeRole `AccessDenied` (typed `smithy.APIError`) → fail-closed with a distinct trust-policy/external-id message; all other assume errors and any simulate error (including a caller lacking `iam:SimulatePrincipalPolicy`) → fail-open. Ambient mode maps assumed-role session ARNs back to role identity ARNs (aws / aws-us-gov / aws-cn).
- Output marker strings are byte-identical to the shell scripts (independently re-verified in review) so log tooling and the template tests carry over unchanged. Credentials and tokens are never printed; every API call is timeout-bounded.

## Testing and review

- 24 test functions: httptest fake for the cloudresourcemanager endpoint; interface-seam fakes for the STS/IAM clients; exit-code contract, marker assertions, pagination merge, ARN-mapping table (gov/cn/federated/root), panic-recovery honesty test.
- Full repo `go build` / `go vet` / `go test ./...` green; new packages golangci-lint clean; `go mod tidy` no-diff (iam/smithy/oauth2/google-api promoted from indirect — already in the module graph via presets).
- Adversarial review pass completed: confirmed findings were the panic-recovery gap (fixed) and comment inaccuracies about lazy credential parsing in oauth2 (corrected — the reviewer verified against library source that bad PEM material surfaces at token fetch, not construction, and deliberately did not add eager PEM validation since a divergent hand-rolled parser could brick every GCP deploy to guard an unreachable case).
- Dockerfile wiring (build in `mars-cli` stage, COPY to `/opt/bin`, symlink to `/usr/local/bin`) mirrors `insideout-reverse-import` exactly; verified statically — no Docker daemon in the dev sandbox, so the multi-arch build is exercised by this repo's CI.

## Rollout

Merging this changes nothing at runtime — the binary ships in the image but nothing invokes it until the follow-up template PR lands (which will also delete the shell implementations). Chain: merge → tag release → ui-core `marsVersion` bump → template swap PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoXMaMHq1LrTJo1DtxwGMR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoXMaMHq1LrTJo1DtxwGMR)_