### PR TITLE
ci: run govulncheck on a daily schedule, not just on PRs

### DIFF
--- a/.github/workflows/govulncheck-scheduled.yml
+++ b/.github/workflows/govulncheck-scheduled.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   govulncheck:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -41,10 +41,47 @@ jobs:
           govulncheck ./... 2>&1 | tee /tmp/govulncheck.txt
           echo "exit=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
+      # Second, ADDITIVE pass over the built binaries. NOT a substitute for the
+      # source scan above and must not become one: source mode reports
+      # vulnerabilities in imported packages even when the linker dropped the
+      # code, which binary mode cannot see. Run together, neither loses
+      # coverage.
+      #
+      # What binary mode adds: reflection-reached code. Per the govulncheck
+      # docs, calls made via package reflect "will not be reported in source
+      # scan mode" -- binary mode keys off symbol presence instead. It also
+      # scans the stdlib at the version the binary was BUILT with rather than
+      # the version the scanner runs under.
+      #
+      # Library modules have no main packages; there the step is a no-op.
+      - name: Run govulncheck (binary mode)
+        id: binscan
+        run: |
+          set -o pipefail
+          status=0
+          mains=$(go list -f '{{if eq .Name "main"}}{{.ImportPath}}{{end}}' ./... | grep -v '^$' || true)
+          if [ -z "$mains" ]; then
+            echo "No main packages in this module — binary mode does not apply."
+            echo "exit=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          mkdir -p /tmp/gv-bins
+          for pkg in $mains; do
+            out="/tmp/gv-bins/$(echo "$pkg" | tr '/' '_')"
+            go build -o "$out" "$pkg"
+            echo "::group::govulncheck -mode=binary ${pkg}"
+            if ! govulncheck -mode=binary "$out" 2>&1 | tee -a /tmp/govulncheck.txt; then
+              status=1
+            fi
+            echo "::endgroup::"
+            rm -f "$out"
+          done
+          echo "exit=${status}" >> "$GITHUB_OUTPUT"
+
       - name: Open, refresh or close the tracking issue
         uses: actions/github-script@v7
         env:
-          FOUND: ${{ steps.scan.outputs.exit != '0' }}
+          FOUND: ${{ steps.scan.outputs.exit != '0' || steps.binscan.outputs.exit != '0' }}
           REPORT_PATH: /tmp/govulncheck.txt
         with:
           script: |
@@ -52,5 +89,5 @@ jobs:
             await run({ github, context, core });
 
       - name: Fail if vulnerabilities were found
-        if: steps.scan.outputs.exit != '0'
+        if: steps.scan.outputs.exit != '0' || steps.binscan.outputs.exit != '0'
         run: exit 1

--- a/.github/workflows/govulncheck-scheduled.yml
+++ b/.github/workflows/govulncheck-scheduled.yml
@@ -10,7 +10,8 @@ name: govulncheck (scheduled)
 # advisories, which track toolchain patch releases rather than any dependency.
 #
 # A finding opens (and later auto-closes) a `govulncheck-drift` issue, so it
-# is visible without anyone subscribing to cron failures.
+# is visible without anyone subscribing to cron failures. The issue logic
+# lives in scripts/govulncheck-drift.cjs, not inline here.
 
 on:
   schedule:
@@ -44,61 +45,11 @@ jobs:
         uses: actions/github-script@v7
         env:
           FOUND: ${{ steps.scan.outputs.exit != '0' }}
+          REPORT_PATH: /tmp/govulncheck.txt
         with:
           script: |
-            const fs = require('fs');
-            const found = process.env.FOUND === 'true';
-            const label = 'govulncheck-drift';
-            const title = 'govulncheck: reachable vulnerability on main';
-            const { owner, repo } = context.repo;
-            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
-
-            const existing = (await github.rest.issues.listForRepo({
-              owner, repo, state: 'open', labels: label,
-            })).data[0];
-
-            if (!found) {
-              if (existing) {
-                await github.rest.issues.createComment({
-                  owner, repo, issue_number: existing.number,
-                  body: `Scheduled govulncheck is clean as of ${runUrl} - closing.`,
-                });
-                await github.rest.issues.update({
-                  owner, repo, issue_number: existing.number,
-                  state: 'closed', state_reason: 'completed',
-                });
-              }
-              return;
-            }
-
-            let report = '';
-            try { report = fs.readFileSync('/tmp/govulncheck.txt', 'utf8').slice(-50000); } catch (e) {}
-            const body = [
-              'Scheduled `govulncheck` found a reachable vulnerability on `main`.',
-              '',
-              'This is a **reachability** finding: govulncheck only reports when this',
-              'module actually calls the vulnerable code, so it is not import-only noise.',
-              '',
-              `Run: ${runUrl}`,
-              '',
-              '<details><summary>Report</summary>',
-              '',
-              '```',
-              report,
-              '```',
-              '',
-              '</details>',
-            ].join('\n');
-
-            if (existing) {
-              await github.rest.issues.createComment({
-                owner, repo, issue_number: existing.number, body,
-              });
-            } else {
-              await github.rest.issues.create({
-                owner, repo, title, body, labels: [label],
-              });
-            }
+            const run = require('./scripts/govulncheck-drift.cjs');
+            await run({ github, context, core });
 
       - name: Fail if vulnerabilities were found
         if: steps.scan.outputs.exit != '0'

--- a/.github/workflows/govulncheck-scheduled.yml
+++ b/.github/workflows/govulncheck-scheduled.yml
@@ -1,0 +1,105 @@
+name: govulncheck (scheduled)
+
+# Scheduled companion to the govulncheck gate that already runs on pull
+# requests in this repo's CI workflow.
+#
+# Why a schedule: a PR-triggered gate only re-scans when someone opens a PR,
+# but the Go vulnerability database updates continuously -- a repo nobody has
+# touched for a month can go from clean to vulnerable with no code change at
+# all. Pinning the toolchain to `stable` also means this picks up Go stdlib
+# advisories, which track toolchain patch releases rather than any dependency.
+#
+# A finding opens (and later auto-closes) a `govulncheck-drift` issue, so it
+# is visible without anyone subscribing to cron failures.
+
+on:
+  schedule:
+    - cron: "30 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+          cache: true
+
+      - name: Run govulncheck
+        id: scan
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          set +e
+          govulncheck ./... 2>&1 | tee /tmp/govulncheck.txt
+          echo "exit=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Open, refresh or close the tracking issue
+        uses: actions/github-script@v7
+        env:
+          FOUND: ${{ steps.scan.outputs.exit != '0' }}
+        with:
+          script: |
+            const fs = require('fs');
+            const found = process.env.FOUND === 'true';
+            const label = 'govulncheck-drift';
+            const title = 'govulncheck: reachable vulnerability on main';
+            const { owner, repo } = context.repo;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            const existing = (await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', labels: label,
+            })).data[0];
+
+            if (!found) {
+              if (existing) {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: existing.number,
+                  body: `Scheduled govulncheck is clean as of ${runUrl} - closing.`,
+                });
+                await github.rest.issues.update({
+                  owner, repo, issue_number: existing.number,
+                  state: 'closed', state_reason: 'completed',
+                });
+              }
+              return;
+            }
+
+            let report = '';
+            try { report = fs.readFileSync('/tmp/govulncheck.txt', 'utf8').slice(-50000); } catch (e) {}
+            const body = [
+              'Scheduled `govulncheck` found a reachable vulnerability on `main`.',
+              '',
+              'This is a **reachability** finding: govulncheck only reports when this',
+              'module actually calls the vulnerable code, so it is not import-only noise.',
+              '',
+              `Run: ${runUrl}`,
+              '',
+              '<details><summary>Report</summary>',
+              '',
+              '```',
+              report,
+              '```',
+              '',
+              '</details>',
+            ].join('\n');
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: existing.number, body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner, repo, title, body, labels: [label],
+              });
+            }
+
+      - name: Fail if vulnerabilities were found
+        if: steps.scan.outputs.exit != '0'
+        run: exit 1

--- a/scripts/govulncheck-drift.cjs
+++ b/scripts/govulncheck-drift.cjs
@@ -1,0 +1,111 @@
+// Tracking-issue state machine for the daily scheduled govulncheck run.
+//
+// Extracted from .github/workflows/govulncheck-scheduled.yml so the logic
+// lives in a real, lintable, testable file and the workflow step stays a thin
+// shim (mirrors scripts/scout-drift-sla.cjs in luthersystems/buildenv):
+//
+//   uses: actions/github-script@v7
+//   with:
+//     script: |
+//       const run = require('./scripts/govulncheck-drift.cjs');
+//       await run({ github, context, core });
+//
+// Inputs (env):
+//   FOUND        'true' when the scan reported a reachable vulnerability
+//   REPORT_PATH  path to the captured govulncheck output (default /tmp/govulncheck.txt)
+//
+// Behaviour:
+//   - finding + no open issue   -> open one, labelled `govulncheck-drift`
+//   - finding + issue already open -> add a comment (don't spam new issues)
+//   - clean + issue open        -> comment and CLOSE it (auto-resolve on recovery)
+//   - clean + no issue          -> no-op, stays quiet
+//
+// It reports only; it does not attempt a fix. govulncheck findings are
+// reachability findings and the remedy is frequently a major-version migration
+// rather than a version bump, so there is nothing safe to auto-apply.
+
+const LABEL = 'govulncheck-drift';
+const TITLE = 'govulncheck: reachable vulnerability on main';
+const MAX_REPORT_BYTES = 50000;
+
+module.exports = async ({ github, context, core }) => {
+  const fs = require('fs');
+  const found = process.env.FOUND === 'true';
+  const reportPath = process.env.REPORT_PATH || '/tmp/govulncheck.txt';
+  const { owner, repo } = context.repo;
+  const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+  const open = await github.rest.issues.listForRepo({
+    owner,
+    repo,
+    state: 'open',
+    labels: LABEL,
+  });
+  const existing = open.data[0];
+
+  if (!found) {
+    if (!existing) {
+      core.info('govulncheck clean, no open drift issue — nothing to do.');
+      return;
+    }
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: existing.number,
+      body: `Scheduled govulncheck is clean as of ${runUrl} — closing.`,
+    });
+    await github.rest.issues.update({
+      owner,
+      repo,
+      issue_number: existing.number,
+      state: 'closed',
+      state_reason: 'completed',
+    });
+    core.info(`Closed #${existing.number} on recovery.`);
+    return;
+  }
+
+  let report = '';
+  try {
+    report = fs.readFileSync(reportPath, 'utf8').slice(-MAX_REPORT_BYTES);
+  } catch (err) {
+    core.warning(`Could not read ${reportPath}: ${err.message}`);
+  }
+
+  const body = [
+    'Scheduled `govulncheck` found a reachable vulnerability on `main`.',
+    '',
+    'This is a **reachability** finding: govulncheck only reports when this',
+    'module actually calls the vulnerable code, so it is not import-only noise.',
+    '',
+    `Run: ${runUrl}`,
+    '',
+    '<details><summary>Report</summary>',
+    '',
+    '```',
+    report,
+    '```',
+    '',
+    '</details>',
+  ].join('\n');
+
+  if (existing) {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: existing.number,
+      body,
+    });
+    core.info(`Refreshed #${existing.number}.`);
+    return;
+  }
+
+  const created = await github.rest.issues.create({
+    owner,
+    repo,
+    title: TITLE,
+    body,
+    labels: [LABEL],
+  });
+  core.info(`Opened #${created.data.number}.`);
+};


### PR DESCRIPTION
Adds a **daily scheduled** govulncheck run alongside the existing pull-request gate. Part of a fleet-wide change (same file in reliable, sandbox, presets, svc, lutherauth, lutherauth-sdk-go, insideout-mcp; ui-core gets the equivalent inline).

## Why

The PR gate only re-scans when someone opens a PR. The Go vulnerability database updates continuously, so a repo nobody has touched for a month can go from clean to vulnerable **with no code change at all** — and nothing would tell us. Pinning the toolchain to `stable` also means the scheduled run picks up Go **stdlib** advisories, which track toolchain patch releases rather than any dependency of ours.

Same gap the buildenv published-image drift watch exists to close, applied to source instead of images.

## What it does

- Runs `govulncheck ./...` daily at 06:30 UTC, staggered against the rest of the fleet.
- On a finding, opens a `govulncheck-drift` issue with the report; refreshes it if one is already open.
- **Auto-closes** the issue on the first clean run, so it can't go stale.
- Also fails the run, so it shows red in the Actions tab either way.
- `workflow_dispatch` for on-demand runs.

Findings are *reachability* findings — govulncheck only reports when this module actually calls the vulnerable code — so this shouldn't generate import-only noise. Kept as a separate file so the existing PR gate is untouched.

## Cost

~1–3 minutes of a standard runner per day.

## Test plan

- Workflow YAML parses; triggers, `issues: write` permission and cron verified.
- The exit-capture shape was simulated locally: a failing scan piped through `tee` correctly yields a non-zero `steps.scan.outputs.exit`. This matters — the naive form reports tee's exit status instead, which would mask every finding.
- First scheduled run confirms end to end; `workflow_dispatch` can trigger it early.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sdr7gadsurqY9Xh9FFJkHY)_