### PR TITLE
fix(deps): clear 9 Dependabot advisories (8 Go, 1 Python)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.5 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/go-git/go-git/v5 v5.19.2 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
-github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
-github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
+github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
+github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
@@ -157,10 +157,10 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
-github.com/go-git/go-billy/v5 v5.8.0 h1:I8hjc3LbBlXTtVuFNJuwYuMiHvQJDq1AT6u4DwDzZG0=
-github.com/go-git/go-billy/v5 v5.8.0/go.mod h1:RpvI/rw4Vr5QA+Z60c6d6LXH0rYJo0uD5SqfmrrheCY=
-github.com/go-git/go-git/v5 v5.18.0 h1:O831KI+0PR51hM2kep6T8k+w0/LIAD490gvqMCvL5hM=
-github.com/go-git/go-git/v5 v5.18.0/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
+github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmmBPA=
+github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
+github.com/go-git/go-git/v5 v5.19.2 h1:wkfn7vOlUBu8ivAWKBWisTiwJK4jYHzTF8Ndv1LyGqY=
+github.com/go-git/go-git/v5 v5.19.2/go.mod h1:QqCBE1EFN5ddFmrliLQ3/ntRCUjZU3EJuwuB/jWEHjk=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -212,6 +212,8 @@ github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
+github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
+github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -222,8 +224,8 @@ github.com/luthersystems/insideout-terraform-presets v0.11.1-0.20260711215456-66
 github.com/luthersystems/insideout-terraform-presets v0.11.1-0.20260711215456-6640d36686f5/go.mod h1:jg2VXnd5+vNojpp+mL+SNHmYx+tKxpQD8rb5S+bJgpE=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
-github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
-github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
+github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=
+github.com/pjbgf/sha1cd v0.6.0/go.mod h1:lhpGlyHLpQZoxMv8HcgXvZEhcGs0PG/vsZnEJ7H0iCM=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 ansible==13.5.0
     # via -r requirements.in
-ansible-core==2.20.4
+ansible-core==2.20.7
     # via ansible
 antlr4-python3-runtime==4.13.2
     # via azure-cli


### PR DESCRIPTION
Part of a fleet-wide Dependabot backlog sweep.

## Go — the go-git chain (8 advisories)

go-git reaches this module only through hashicorp/terraform-exec's test chain:

```
tfexec -> tfexec.test -> internal/testutil -> hc-install/build -> go-git
```

So it sits in `go.sum` without ever being compiled into a mars binary. It still carries 8 GitHub advisories, so it gets pinned forward.

| Module | main had | now | Clears |
|---|---|---|---|
| `github.com/go-git/go-git/v5` | v5.18.0 | v5.19.2 | 2 high, 3 moderate, 1 low |
| `github.com/go-git/go-billy/v5` | v5.8.0 | v5.9.0 | 1 high, 1 moderate |

After `go mod tidy` only go-git/v5 needs an explicit go.mod line; go-billy v5.9.0 plus `filepath-securejoin`, `sha1cd` and `cpuid` come along as the pins go-git v5.19.2 requires. Both target versions were checked against main first — neither is a stale downgrade.

## Python — ansible-core (1 advisory)

`ansible-core` 2.20.4 -> 2.20.7 clears GHSA-w8p5-mx5w-cpqj (high).

- 2.20.7 is a stable release. The advisory names `2.20.7rc1` as the fix point; the stable 2.20.7 is at or above it.
- It satisfies `ansible 13.5.0`'s `ansible-core~=2.20.4` constraint (`>=2.20.4, <2.21`).
- Its `requires_dist` is identical to 2.20.4's (`jinja2>=3.1.0`, `PyYAML>=5.1`, `cryptography`, `packaging`, `resolvelib<2.0.0,>=0.8.0`), all already satisfied by existing pins.

`requirements.in` is unchanged — this is a targeted pin bump, not a pip-compile regeneration.

## Deliberately NOT fixed here

**The four `cryptography` 46.0.7 advisories** (3 high, 1 moderate). These cannot be resolved by a bump:

- Clearing all four needs `cryptography >= 50.0.0`. Even `>= 49.0.0` clears only three.
- `msal 1.35.0b1` requires `cryptography<49,>=2.5` — hard cap below 49.
- `pyopenssl 26.0.0` requires `cryptography<47,>=46.0.0` — hard cap below 47.
- Both are pulled by `azure-cli 2.84.0`.

There is no intermediate pin that satisfies everything, so clearing these means bumping azure-cli, regenerating `requirements.txt` with pip-compile, and rebuilding + testing the mars image. That is a real piece of work with image-level blast radius, so it is left for a human. Rough size: half a day, mostly validating the azure-cli surface the ansible roles use.

**`paramiko 3.5.1`** (GHSA-r374-rxx8-8654, low) — no fixed version released upstream.

## Verification

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test ./...` — pass (all packages)
- OSV re-scan of the resulting `go.sum` — 0 GitHub advisories (was 8)

The Python change could **not** be resolver-tested locally: this sandbox runs Python 3.11 and `ansible 13.5.0` requires >=3.12, so `pip install --dry-run` refuses. The constraint math above is the evidence; the image build in CI is the real gate.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sdr7gadsurqY9Xh9FFJkHY)_